### PR TITLE
Fixed memory leak in vertx-hazelcast.

### DIFF
--- a/src/main/java/io/vertx/spi/cluster/hazelcast/impl/HazelcastAsyncMultiMap.java
+++ b/src/main/java/io/vertx/spi/cluster/hazelcast/impl/HazelcastAsyncMultiMap.java
@@ -103,7 +103,7 @@ public class HazelcastAsyncMultiMap<K, V> implements AsyncMultiMap<K, V>, EntryL
         } else {
           sids = new ChoosableSet<>(0);
         }
-        ChoosableSet<V> prev = cache.putIfAbsent(k, sids);
+        ChoosableSet<V> prev = (sids.isEmpty()) ? null : cache.putIfAbsent(k, sids);
         if (prev != null) {
           // Merge them
           prev.merge(sids);

--- a/src/test/java/io/vertx/test/core/HazelcastAsyncMultiMapTest.java
+++ b/src/test/java/io/vertx/test/core/HazelcastAsyncMultiMapTest.java
@@ -16,6 +16,14 @@
 
 package io.vertx.test.core;
 
+import java.lang.reflect.Field;
+import java.util.Map;
+import java.util.UUID;
+
+import org.junit.Test;
+
+import io.vertx.core.net.impl.ServerID;
+import io.vertx.core.spi.cluster.ChoosableIterable;
 import io.vertx.core.spi.cluster.ClusterManager;
 import io.vertx.spi.cluster.hazelcast.HazelcastClusterManager;
 
@@ -34,4 +42,45 @@ public class HazelcastAsyncMultiMapTest extends AsyncMultiMapTest {
     return new HazelcastClusterManager();
   }
 
+  @Test
+  public void shouldNotAddToMapCacheIfKeyDoesntAlreadyExist() throws Exception {
+    String nonexistentKey = "non-existent-key." + UUID.randomUUID();
+
+    map.get(nonexistentKey, ar -> {
+      if (ar.succeeded()) {
+        try {
+          ChoosableIterable<ServerID> s = ar.result();
+          Map<String, ChoosableIterable<ServerID>> cache = getCacheFromMap();
+
+          // System.err.println("CACHE CONTENTS: " + cache);
+
+          // check result
+          assertNotNull(s);
+          assertTrue(s.isEmpty());
+
+          // check cache
+          assertNotNull(cache);
+          assertFalse(
+              "Map cache should not contain key " + nonexistentKey,
+              cache.containsKey(nonexistentKey));
+
+        } catch (Exception e) {
+          fail(e.toString());
+        } finally {
+          testComplete();
+        }
+      } else {
+        fail(ar.cause().toString());
+      }
+    });
+
+    await();
+  }
+
+  @SuppressWarnings("unchecked")
+  private Map<String, ChoosableIterable<ServerID>> getCacheFromMap() throws Exception {
+    Field field = map.getClass().getDeclaredField("cache");
+    field.setAccessible(true);
+    return (Map<String, ChoosableIterable<ServerID>>) field.get(map);
+  }
 }


### PR DESCRIPTION
Memory leak occurs when message is sent to non-existent
address on clustered event bus.

HazelcastAsyncMultiMap's cache gets polluted by empty
sets which are never removed.