### PR TITLE
Add support for external hazelcast instance

### DIFF
--- a/src/main/asciidoc/index.adoc
+++ b/src/main/asciidoc/index.adoc
@@ -93,6 +93,25 @@ multicast so you must have multicast enabled on your network for this to work.
 For full documentation on how to configure the transport differently or use a different transport please consult the
 Hazelcast documentation.
 
+== Using an existing Hazelcast cluster
+
+You can pass an existing `HazelcastInstance` in the cluster manager to reuse an existing cluster:
+
+[source,java]
+----
+ClusterManager mgr = new HazelcastClusterManager(hazelcastInstance);
+VertxOptions options = new VertxOptions().setClusterManager(mgr);
+Vertx.clusteredVertx(options, res -> {
+  if (res.succeeded()) {
+    Vertx vertx = res.result();
+  } else {
+    // failed!
+  }
+});
+----
+
+In this case, vert.x is not the cluster owner and so do not shutdown the cluster on close.
+
 == Trouble shooting clustering
 
 If the default multicast configuration is not working here are some common causes:

--- a/src/main/java/io/vertx/spi/cluster/hazelcast/examples/Examples.java
+++ b/src/main/java/io/vertx/spi/cluster/hazelcast/examples/Examples.java
@@ -17,6 +17,7 @@
 package io.vertx.spi.cluster.hazelcast.examples;
 
 import com.hazelcast.config.Config;
+import com.hazelcast.core.HazelcastInstance;
 import io.vertx.core.Vertx;
 import io.vertx.core.VertxOptions;
 import io.vertx.core.spi.cluster.ClusterManager;
@@ -52,6 +53,18 @@ public class Examples {
 
     VertxOptions options = new VertxOptions().setClusterManager(mgr);
 
+    Vertx.clusteredVertx(options, res -> {
+      if (res.succeeded()) {
+        Vertx vertx = res.result();
+      } else {
+        // failed!
+      }
+    });
+  }
+
+  public void example3(HazelcastInstance hazelcastInstance) {
+    ClusterManager mgr = new HazelcastClusterManager(hazelcastInstance);
+    VertxOptions options = new VertxOptions().setClusterManager(mgr);
     Vertx.clusteredVertx(options, res -> {
       if (res.succeeded()) {
         Vertx vertx = res.result();

--- a/src/main/java/io/vertx/spi/cluster/hazelcast/package-info.java
+++ b/src/main/java/io/vertx/spi/cluster/hazelcast/package-info.java
@@ -70,6 +70,17 @@
  * For full documentation on how to configure the transport differently or use a different transport please consult the
  * Hazelcast documentation.
  *
+ * == Using an existing Hazelcast cluster
+ *
+ * You can pass an existing `HazelcastInstance` in the cluster manager to reuse an existing cluster:
+ *
+ * [source,$lang]
+ * ----
+ * {@link io.vertx.spi.cluster.hazelcast.examples.Examples#example3(com.hazelcast.core.HazelcastInstance)}
+ * ----
+ *
+ * In this case, vert.x is not the cluster owner and so do not shutdown the cluster on close.
+ *
  * == Trouble shooting clustering
  *
  * If the default multicast configuration is not working here are some common causes:

--- a/src/test/java/io/vertx/test/core/ProgrammaticHazelcastClusterManagerTest.java
+++ b/src/test/java/io/vertx/test/core/ProgrammaticHazelcastClusterManagerTest.java
@@ -17,10 +17,16 @@
 package io.vertx.test.core;
 
 import com.hazelcast.config.Config;
+import com.hazelcast.core.Hazelcast;
+import com.hazelcast.core.HazelcastInstance;
 import io.vertx.core.Vertx;
 import io.vertx.core.VertxOptions;
+import io.vertx.core.shareddata.LocalMap;
 import io.vertx.spi.cluster.hazelcast.HazelcastClusterManager;
 import org.junit.Test;
+
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.BooleanSupplier;
 
 /**
  * @author <a href="http://tfox.org">Tim Fox</a>
@@ -60,5 +66,104 @@ public class ProgrammaticHazelcastClusterManagerTest extends AsyncTestBase {
     Config config = new Config();
     HazelcastClusterManager mgr = new HazelcastClusterManager(config);
     testProgrammatic(mgr, config);
+  }
+
+  @Test
+  public void testCustomHazelcastInstance() throws Exception {
+    HazelcastInstance instance = Hazelcast.newHazelcastInstance(new Config());
+    HazelcastClusterManager mgr = new HazelcastClusterManager(instance);
+    testProgrammatic(mgr, instance.getConfig());
+  }
+
+  @Test
+  public void testEventBusWhenUsingACustomHazelcastInstance() throws Exception {
+    HazelcastInstance instance1 = Hazelcast.newHazelcastInstance(new Config());
+    HazelcastInstance instance2 = Hazelcast.newHazelcastInstance(new Config());
+
+    HazelcastClusterManager mgr1 = new HazelcastClusterManager(instance1);
+    HazelcastClusterManager mgr2 = new HazelcastClusterManager(instance2);
+    VertxOptions options1 = new VertxOptions().setClusterManager(mgr1).setClustered(true).setClusterHost("127.0.0.1");
+    VertxOptions options2 = new VertxOptions().setClusterManager(mgr2).setClustered(true).setClusterHost("127.0.0.1");
+
+    AtomicReference<Vertx> vertx1 = new AtomicReference<>();
+    AtomicReference<Vertx> vertx2 = new AtomicReference<>();
+
+    Vertx.clusteredVertx(options1, res -> {
+      assertTrue(res.succeeded());
+      assertNotNull(mgr1.getHazelcastInstance());
+      res.result().eventBus().consumer("news", message -> {
+        assertNotNull(message);
+        assertTrue(message.body().equals("hello"));
+        testComplete();
+      });
+      vertx1.set(res.result());
+    });
+
+    waitUntil(() -> vertx1.get() != null);
+
+    Vertx.clusteredVertx(options2, res -> {
+      assertTrue(res.succeeded());
+      assertNotNull(mgr2.getHazelcastInstance());
+      vertx2.set(res.result());
+      res.result().eventBus().send("news", "hello");
+    });
+
+    await();
+    vertx1.get().close();
+    vertx2.get().close();
+
+    assertTrue(instance1.getLifecycleService().isRunning());
+    assertTrue(instance2.getLifecycleService().isRunning());
+
+    instance1.shutdown();
+    instance2.shutdown();
+  }
+
+  @Test
+  public void testSharedDataUsingCustomHazelcast() throws Exception {
+    HazelcastInstance instance1 = Hazelcast.newHazelcastInstance(new Config());
+    HazelcastInstance instance2 = Hazelcast.newHazelcastInstance(new Config());
+
+    HazelcastClusterManager mgr1 = new HazelcastClusterManager(instance1);
+    HazelcastClusterManager mgr2 = new HazelcastClusterManager(instance2);
+    VertxOptions options1 = new VertxOptions().setClusterManager(mgr1).setClustered(true).setClusterHost("127.0.0.1");
+    VertxOptions options2 = new VertxOptions().setClusterManager(mgr2).setClustered(true).setClusterHost("127.0.0.1");
+
+    AtomicReference<Vertx> vertx1 = new AtomicReference<>();
+    AtomicReference<Vertx> vertx2 = new AtomicReference<>();
+
+    Vertx.clusteredVertx(options1, res -> {
+      assertTrue(res.succeeded());
+      assertNotNull(mgr1.getHazelcastInstance());
+      res.result().sharedData().getClusterWideMap("mymap1", ar -> {
+        ar.result().put("news", "hello", v -> {
+          vertx1.set(res.result());
+        });
+      });
+    });
+
+    waitUntil(() -> vertx1.get() != null);
+
+    Vertx.clusteredVertx(options2, res -> {
+      assertTrue(res.succeeded());
+      assertNotNull(mgr2.getHazelcastInstance());
+      vertx2.set(res.result());
+      res.result().sharedData().getClusterWideMap("mymap1", ar -> {
+        ar.result().get("news", r -> {
+          assertEquals("hello", r.result());
+          testComplete();
+        });
+      });
+    });
+
+    await();
+    vertx1.get().close();
+    vertx2.get().close();
+
+    assertTrue(instance1.getLifecycleService().isRunning());
+    assertTrue(instance2.getLifecycleService().isRunning());
+
+    instance1.shutdown();
+    instance2.shutdown();
   }
 }


### PR DESCRIPTION
Add a constructor that let the user to inject a custom hazelcast instance (custom in the sense not created by vert.x).

