### PR TITLE
made some cleanups for CI builds' script

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,7 @@
   <properties>
     <stack.version>3.3.0-SNAPSHOT</stack.version>
     <asciidoc.dir>${project.basedir}/src/main/asciidoc</asciidoc.dir>
+    <hazelcast.version>3.5.2</hazelcast.version>
   </properties>
 
   <dependencyManagement>
@@ -41,7 +42,7 @@
     <dependency>
       <groupId>com.hazelcast</groupId>
       <artifactId>hazelcast</artifactId>
-      <version>3.5.2</version>
+      <version>${hazelcast.version}</version>
       <!-- Exclude some stuff that we don't need and probably are just hazelcast test time dependencies that leaked into
       compile -->
       <exclusions>
@@ -86,7 +87,7 @@
     <dependency>
       <groupId>com.hazelcast</groupId>
       <artifactId>hazelcast-client</artifactId>
-      <version>3.5.2</version>
+      <version>${hazelcast.version}</version>
       <scope>test</scope>
     </dependency>
     


### PR DESCRIPTION
We want to run your code base with different version of hazelcast at our CI environment so i made basic cleanup for the hazelcast version at pom.xml. In this way, i can easily change hazelcast version via basic one line script.