### PR TITLE
Hazelcast async map and counter implementations

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
   <properties>
     <stack.version>3.3.0-SNAPSHOT</stack.version>
     <asciidoc.dir>${project.basedir}/src/main/asciidoc</asciidoc.dir>
-    <hazelcast.version>3.6.1</hazelcast.version>
+    <hazelcast.version>3.6.2</hazelcast.version>
   </properties>
 
   <dependencyManagement>

--- a/src/main/asciidoc/java/index.adoc
+++ b/src/main/asciidoc/java/index.adoc
@@ -217,7 +217,7 @@ See the http://docs.hazelcast.org/docs/3.6.1/manual/html-single/index.html#loggi
 
 == Using a different Hazelcast version
 
-You may want to use a different version of Hazelcast. The default version is `3.6.1`. To do so, you
+You may want to use a different version of Hazelcast. The default version is `3.6.2`. To do so, you
 need to:
 
 * put the version you want in the application classpath

--- a/src/main/asciidoc/java/index.adoc
+++ b/src/main/asciidoc/java/index.adoc
@@ -134,6 +134,17 @@ Notice that the custom Hazelcast instance need to be configured with:
 cluster as they do not notify when they leave the cluster and you may loose data, or leave the cluster in an
 inconsistent state. See https://github.com/vert-x3/vertx-hazelcast/issues/24 for more details.
 
+== Using Hazelcast async methods
+Hazelcast's `IMap` and `IAtomicLong` interfaces can be used with async methods returning `ICompletableFuture<V>`,
+a natural fit for Vert.x threading model. Even though these interfaces have been available for a long time, they are not
+provided by the public `HazelcastInstance` API.
+
+The default behavior of the `HazelcastClusterManager` is to use the public API. Supplying the option
+`-Dvertx.hazelcast.async-api=true` on JVM startup, will indicate that the async Hazelcast API methods will be used to
+communicate with the hazelcast cluster. Effectively, this means that when this option is enabled,
+execution of all `Counter` operations and `AsyncMap.get`,`AsyncMap.put` and `AsyncMap.remove` operations will
+occur in the calling thread (the event loop), instead of a worker thread with `vertx.executeBlocking`.
+
 == Trouble shooting clustering
 
 If the default multicast configuration is not working here are some common causes:

--- a/src/main/java/io/vertx/spi/cluster/hazelcast/HazelcastClusterManager.java
+++ b/src/main/java/io/vertx/spi/cluster/hazelcast/HazelcastClusterManager.java
@@ -31,8 +31,10 @@ import io.vertx.core.shareddata.Counter;
 import io.vertx.core.shareddata.Lock;
 import io.vertx.core.spi.cluster.AsyncMultiMap;
 import io.vertx.core.spi.cluster.NodeListener;
+import io.vertx.spi.cluster.hazelcast.impl.HazelcastInternalAsyncCounter;
 import io.vertx.spi.cluster.hazelcast.impl.HazelcastAsyncMap;
 import io.vertx.spi.cluster.hazelcast.impl.HazelcastAsyncMultiMap;
+import io.vertx.spi.cluster.hazelcast.impl.HazelcastInternalAsyncMap;
 
 import java.io.BufferedInputStream;
 import java.io.IOException;
@@ -56,6 +58,26 @@ public class HazelcastClusterManager implements ExtendedClusterManager, Membersh
   private static final String DEFAULT_CONFIG_FILE = "default-cluster.xml";
   private static final String CONFIG_FILE = "cluster.xml";
 
+  /**
+   * Set "vertx.hazelcast.async-api" system property to {@code true} to use the
+   * (currently) non-public Hazelcast async API. When {@code true}, the {@link AsyncMap} implementation
+   * will be backed by {@link HazelcastInternalAsyncMap} and the {@link Counter} is supplied by
+   * {@link HazelcastInternalAsyncCounter}, otherwise default to {@link HazelcastAsyncMap}
+   * and {@link HazelcastCounter}.
+   */
+  private static final String OPTION_USE_HZ_ASYNC_API = "vertx.hazelcast.async-api";
+
+  private static final boolean USE_HZ_ASYNC_API;
+
+  static {
+    boolean b = false;
+    try {
+      b = Boolean.valueOf(System.getProperty(OPTION_USE_HZ_ASYNC_API, "false"));
+    }
+    catch (Exception e) {
+    }
+    USE_HZ_ASYNC_API = b;
+  }
 
   private Vertx vertx;
 
@@ -164,7 +186,7 @@ public class HazelcastClusterManager implements ExtendedClusterManager, Membersh
   public <K, V> void getAsyncMap(String name, Handler<AsyncResult<AsyncMap<K, V>>> resultHandler) {
     vertx.executeBlocking(fut -> {
       IMap<K, V> map = hazelcast.getMap(name);
-      fut.complete(new HazelcastAsyncMap<>(vertx, map));
+      fut.complete(USE_HZ_ASYNC_API ? new HazelcastInternalAsyncMap<>(vertx, map) : new HazelcastAsyncMap<>(vertx, map));
     }, resultHandler);
   }
 
@@ -194,7 +216,13 @@ public class HazelcastClusterManager implements ExtendedClusterManager, Membersh
 
   @Override
   public void getCounter(String name, Handler<AsyncResult<Counter>> resultHandler) {
-    vertx.executeBlocking(fut ->  fut.complete(new HazelcastCounter(hazelcast.getAtomicLong(name))), resultHandler);
+    vertx.executeBlocking(fut ->
+      fut.complete(
+              USE_HZ_ASYNC_API ?
+                      new HazelcastInternalAsyncCounter(vertx, (AsyncAtomicLong) hazelcast.getAtomicLong(name)) :
+                      new HazelcastCounter(hazelcast.getAtomicLong(name))
+      )
+    , resultHandler);
   }
 
   public synchronized void leave(Handler<AsyncResult<Void>> resultHandler) {

--- a/src/main/java/io/vertx/spi/cluster/hazelcast/HazelcastClusterManager.java
+++ b/src/main/java/io/vertx/spi/cluster/hazelcast/HazelcastClusterManager.java
@@ -308,16 +308,18 @@ public class HazelcastClusterManager implements ExtendedClusterManager, Membersh
   }
 
   public void beforeLeave() {
-    if (isActive()) {
-      if (! customHazelcastCluster  && hazelcast.getLifecycleService().isRunning()) {
-        ILock lock = hazelcast.getLock("vertx.shutdownlock");
-        try {
-          lock.tryLock(30, TimeUnit.SECONDS);
-        } catch (Exception ignore) {
+    vertx.executeBlocking(fut ->  {
+      if (isActive()) {
+        if (! customHazelcastCluster  && hazelcast.getLifecycleService().isRunning()) {
+          ILock lock = hazelcast.getLock("vertx.shutdownlock");
+          try {
+            lock.tryLock(30, TimeUnit.SECONDS);
+          } catch (Exception ignore) {
+          }
+          // The lock should be automatically released when the node is shutdown
         }
-        // The lock should be automatically released when the node is shutdown
       }
-    }
+    }, null);
   }
 
   public HazelcastInstance getHazelcastInstance() {

--- a/src/main/java/io/vertx/spi/cluster/hazelcast/impl/ConversionUtils.java
+++ b/src/main/java/io/vertx/spi/cluster/hazelcast/impl/ConversionUtils.java
@@ -1,0 +1,88 @@
+package io.vertx.spi.cluster.hazelcast.impl;
+
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.DataSerializable;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.shareddata.impl.ClusterSerializable;
+
+import java.io.IOException;
+
+class ConversionUtils {
+    static <T> T convertParam(T obj) {
+        if (obj instanceof ClusterSerializable) {
+            ClusterSerializable cobj = (ClusterSerializable)obj;
+            return (T)(new DataSerializableHolder(cobj));
+        } else {
+            return obj;
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    static  <T> T convertReturn(Object obj) {
+        if (obj instanceof DataSerializableHolder) {
+            DataSerializableHolder cobj = (DataSerializableHolder)obj;
+            return (T)cobj.clusterSerializable();
+        } else {
+            return (T)obj;
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static final class DataSerializableHolder implements DataSerializable {
+
+        private ClusterSerializable clusterSerializable;
+
+        public DataSerializableHolder() {
+        }
+
+        private DataSerializableHolder(ClusterSerializable clusterSerializable) {
+            this.clusterSerializable = clusterSerializable;
+        }
+
+        @Override
+        public void writeData(ObjectDataOutput objectDataOutput) throws IOException {
+            objectDataOutput.writeUTF(clusterSerializable.getClass().getName());
+            Buffer buffer = Buffer.buffer();
+            clusterSerializable.writeToBuffer(buffer);
+            byte[] bytes = buffer.getBytes();
+            objectDataOutput.writeInt(bytes.length);
+            objectDataOutput.write(bytes);
+        }
+
+        @Override
+        public void readData(ObjectDataInput objectDataInput) throws IOException {
+            String className = objectDataInput.readUTF();
+            int length = objectDataInput.readInt();
+            byte[] bytes = new byte[length];
+            objectDataInput.readFully(bytes);
+            try {
+                Class<?> clazz = Thread.currentThread().getContextClassLoader().loadClass(className);
+                clusterSerializable = (ClusterSerializable)clazz.newInstance();
+                clusterSerializable.readFromBuffer(0, Buffer.buffer(bytes));
+            } catch (Exception e) {
+                throw new IllegalStateException("Failed to load class " + e.getMessage(), e);
+            }
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (!(o instanceof DataSerializableHolder)) return false;
+            DataSerializableHolder that = (DataSerializableHolder) o;
+            if (clusterSerializable != null ? !clusterSerializable.equals(that.clusterSerializable) : that.clusterSerializable != null) {
+                return false;
+            }
+            return true;
+        }
+
+        @Override
+        public int hashCode() {
+            return clusterSerializable != null ? clusterSerializable.hashCode() : 0;
+        }
+
+        public ClusterSerializable clusterSerializable() {
+            return clusterSerializable;
+        }
+    }
+}

--- a/src/main/java/io/vertx/spi/cluster/hazelcast/impl/HandlerCallBackAdapter.java
+++ b/src/main/java/io/vertx/spi/cluster/hazelcast/impl/HandlerCallBackAdapter.java
@@ -1,0 +1,32 @@
+package io.vertx.spi.cluster.hazelcast.impl;
+
+import com.hazelcast.core.ExecutionCallback;
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Handler;
+
+import static io.vertx.core.Future.failedFuture;
+import static io.vertx.core.Future.succeededFuture;
+import static io.vertx.spi.cluster.hazelcast.impl.ConversionUtils.convertReturn;
+
+class HandlerCallBackAdapter<V> implements ExecutionCallback<V> {
+
+    private final Handler<AsyncResult<V>> asyncResultHandler;
+
+    public HandlerCallBackAdapter(Handler<AsyncResult<V>> asyncResultHandler) {
+        this.asyncResultHandler = asyncResultHandler;
+    }
+
+    @Override
+    public void onResponse(V v) {
+        setResult(succeededFuture(convertReturn(v)));
+    }
+
+    @Override
+    public void onFailure(Throwable throwable) {
+        setResult(failedFuture(throwable));
+    }
+
+    protected void setResult(AsyncResult<V> object) {
+        asyncResultHandler.handle(object);
+    }
+}

--- a/src/main/java/io/vertx/spi/cluster/hazelcast/impl/HazelcastInternalAsyncCounter.java
+++ b/src/main/java/io/vertx/spi/cluster/hazelcast/impl/HazelcastInternalAsyncCounter.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2011-2016 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ *     The Eclipse Public License is available at
+ *     http://www.eclipse.org/legal/epl-v10.html
+ *
+ *     The Apache License v2.0 is available at
+ *     http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */package io.vertx.spi.cluster.hazelcast.impl;
+
+import com.hazelcast.core.AsyncAtomicLong;
+import com.hazelcast.core.ICompletableFuture;
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Handler;
+import io.vertx.core.Vertx;
+import io.vertx.core.shareddata.Counter;
+
+import java.util.Objects;
+import java.util.concurrent.Callable;
+
+/**
+ *
+ */
+public class HazelcastInternalAsyncCounter
+        implements Counter {
+
+    private final AsyncAtomicLong atomicLong;
+    private final Vertx vertx;
+
+
+    public HazelcastInternalAsyncCounter(Vertx vertx, AsyncAtomicLong atomicLong) {
+        this.vertx = vertx;
+        this.atomicLong = atomicLong;
+    }
+
+    @Override
+    public void get(Handler<AsyncResult<Long>> resultHandler) {
+        Objects.requireNonNull(resultHandler, "resultHandler");
+        executeAsync(atomicLong.asyncGet(), resultHandler);
+    }
+
+    @Override
+    public void incrementAndGet(Handler<AsyncResult<Long>> resultHandler) {
+        Objects.requireNonNull(resultHandler, "resultHandler");
+        executeAsync(atomicLong.asyncIncrementAndGet(), resultHandler);
+    }
+
+    @Override
+    public void getAndIncrement(Handler<AsyncResult<Long>> resultHandler) {
+        Objects.requireNonNull(resultHandler, "resultHandler");
+        executeAsync(atomicLong.asyncGetAndIncrement(), resultHandler);
+    }
+
+    @Override
+    public void decrementAndGet(Handler<AsyncResult<Long>> resultHandler) {
+        Objects.requireNonNull(resultHandler, "resultHandler");
+        executeAsync(atomicLong.asyncDecrementAndGet(), resultHandler);
+    }
+
+    @Override
+    public void addAndGet(long value, Handler<AsyncResult<Long>> resultHandler) {
+        Objects.requireNonNull(resultHandler, "resultHandler");
+        executeAsync(atomicLong.asyncAddAndGet(value), resultHandler);
+    }
+
+    @Override
+    public void getAndAdd(long value, Handler<AsyncResult<Long>> resultHandler) {
+        Objects.requireNonNull(resultHandler, "resultHandler");
+        executeAsync(atomicLong.asyncGetAndAdd(value), resultHandler);
+    }
+
+    @Override
+    public void compareAndSet(long expected, long value, Handler<AsyncResult<Boolean>> resultHandler) {
+        Objects.requireNonNull(resultHandler, "resultHandler");
+        executeAsync(atomicLong.asyncCompareAndSet(expected, value),
+                        resultHandler);
+    }
+
+    private <T> void executeAsync(ICompletableFuture<T> future,
+                                  Handler<AsyncResult<T>> resultHandler) {
+        future.andThen(
+                new HandlerCallBackAdapter(resultHandler),
+                VertxExecutorAdapter.getOrCreate(vertx.getOrCreateContext())
+        );
+    }
+}

--- a/src/main/java/io/vertx/spi/cluster/hazelcast/impl/HazelcastInternalAsyncMap.java
+++ b/src/main/java/io/vertx/spi/cluster/hazelcast/impl/HazelcastInternalAsyncMap.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright (c) 2011-2016 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ *     The Eclipse Public License is available at
+ *     http://www.eclipse.org/legal/epl-v10.html
+ *
+ *     The Apache License v2.0 is available at
+ *     http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+
+package io.vertx.spi.cluster.hazelcast.impl;
+
+import com.hazelcast.core.ICompletableFuture;
+import com.hazelcast.core.IMap;
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Handler;
+import io.vertx.core.Vertx;
+import io.vertx.core.shareddata.AsyncMap;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
+
+import static io.vertx.spi.cluster.hazelcast.impl.ConversionUtils.convertParam;
+import static io.vertx.spi.cluster.hazelcast.impl.ConversionUtils.convertReturn;
+
+public class HazelcastInternalAsyncMap<K, V> implements AsyncMap<K, V> {
+
+  private final Vertx vertx;
+  private final IMap<K, V> map;
+
+  public HazelcastInternalAsyncMap(Vertx vertx, IMap<K, V> map) {
+    this.vertx = vertx;
+    this.map = map;
+  }
+
+  @Override
+  public void get(K k, Handler<AsyncResult<V>> asyncResultHandler) {
+    executeAsync(
+            (ICompletableFuture<V>)map.getAsync(convertParam(k)),
+            asyncResultHandler
+    );
+  }
+
+  @Override
+  public void put(K k, V v, Handler<AsyncResult<Void>> completionHandler) {
+    K kk = convertParam(k);
+    V vv = convertParam(v);
+    executeAsyncVoid(
+            (ICompletableFuture<Void>)map.putAsync(kk, vv),
+            completionHandler
+    );
+  }
+
+  @Override
+  public void putIfAbsent(K k, V v, Handler<AsyncResult<V>> resultHandler) {
+    K kk = convertParam(k);
+    V vv = convertParam(v);
+    vertx.executeBlocking(fut -> fut.complete(convertReturn(map.putIfAbsent(kk, HazelcastServerID.convertServerID(vv)))),
+                          resultHandler);
+  }
+
+  @Override
+  public void put(K k, V v, long ttl, Handler<AsyncResult<Void>> completionHandler) {
+    K kk = convertParam(k);
+    V vv = convertParam(v);
+    executeAsyncVoid(
+            (ICompletableFuture<Void>) map.putAsync(kk, vv, ttl, TimeUnit.MILLISECONDS),
+            completionHandler
+    );
+  }
+
+  @Override
+  public void putIfAbsent(K k, V v, long ttl, Handler<AsyncResult<V>> resultHandler) {
+    K kk = convertParam(k);
+    V vv = convertParam(v);
+    vertx.executeBlocking(fut -> fut.complete(convertReturn(map.putIfAbsent(kk, HazelcastServerID.convertServerID(vv),
+      ttl, TimeUnit.MILLISECONDS))), resultHandler);
+  }
+
+  @Override
+  public void remove(K k, Handler<AsyncResult<V>> resultHandler) {
+    K kk = convertParam(k);
+    executeAsync(
+            (ICompletableFuture<V>)map.removeAsync(kk),
+            resultHandler
+    );
+  }
+
+  @Override
+  public void removeIfPresent(K k, V v, Handler<AsyncResult<Boolean>> resultHandler) {
+    K kk = convertParam(k);
+    V vv = convertParam(v);
+    vertx.executeBlocking(fut -> fut.complete(map.remove(kk, vv)), resultHandler);
+  }
+
+  @Override
+  public void replace(K k, V v, Handler<AsyncResult<V>> resultHandler) {
+    K kk = convertParam(k);
+    V vv = convertParam(v);
+    vertx.executeBlocking(fut -> fut.complete(convertReturn(map.replace(kk, vv))), resultHandler);
+  }
+
+  @Override
+  public void replaceIfPresent(K k, V oldValue, V newValue, Handler<AsyncResult<Boolean>> resultHandler) {
+    K kk = convertParam(k);
+    V vv = convertParam(oldValue);
+    V vvv = convertParam(newValue);
+    vertx.executeBlocking(fut -> fut.complete(map.replace(kk, vv, vvv)), resultHandler);
+  }
+
+  @Override
+  public void clear(Handler<AsyncResult<Void>> resultHandler) {
+    vertx.executeBlocking(fut -> {
+      map.clear();
+      fut.complete();
+    }, resultHandler);
+  }
+
+  @Override
+  public void size(Handler<AsyncResult<Integer>> resultHandler) {
+    vertx.executeBlocking(fut -> fut.complete(map.size()), resultHandler);
+  }
+
+  private <T> void executeAsync(ICompletableFuture<T> future,
+                              Handler<AsyncResult<T>> resultHandler) {
+    future.andThen(
+            new HandlerCallBackAdapter(resultHandler),
+            VertxExecutorAdapter.getOrCreate(vertx.getOrCreateContext())
+    );
+  }
+
+  private void executeAsyncVoid(ICompletableFuture<Void> future,
+                              Handler<AsyncResult<Void>> resultHandler) {
+    future.andThen(
+            new VoidHandlerCallBackAdapter(resultHandler),
+            VertxExecutorAdapter.getOrCreate(vertx.getOrCreateContext())
+    );
+  }
+
+}

--- a/src/main/java/io/vertx/spi/cluster/hazelcast/impl/VertxExecutorAdapter.java
+++ b/src/main/java/io/vertx/spi/cluster/hazelcast/impl/VertxExecutorAdapter.java
@@ -6,14 +6,29 @@ import java.util.concurrent.Executor;
 
 final class VertxExecutorAdapter implements Executor {
 
+    private static final String CONTEXT_KEY_HZ_VERTX_EXECUTOR_ADAPTER = "io.vertx.spi.cluster.hazelcast.impl.VertxExecutorAdapter";
     private final Context context;
 
-    VertxExecutorAdapter(Context context) {
+    private VertxExecutorAdapter(Context context) {
         this.context = context;
     }
 
     @Override
     public void execute(Runnable command) {
         context.runOnContext(aVoid -> command.run());
+    }
+
+    public static VertxExecutorAdapter getOrCreate(Context context) {
+        // Context.contextData() is a ConcurrentHashMap so we are not doing any external synchronisation here
+        VertxExecutorAdapter vertxExecutorAdapter = context.get(CONTEXT_KEY_HZ_VERTX_EXECUTOR_ADAPTER);
+
+        if (vertxExecutorAdapter != null) {
+            return vertxExecutorAdapter;
+        }
+        else {
+            vertxExecutorAdapter = new VertxExecutorAdapter(context);
+            context.put(CONTEXT_KEY_HZ_VERTX_EXECUTOR_ADAPTER, vertxExecutorAdapter);
+            return vertxExecutorAdapter;
+        }
     }
 }

--- a/src/main/java/io/vertx/spi/cluster/hazelcast/impl/VertxExecutorAdapter.java
+++ b/src/main/java/io/vertx/spi/cluster/hazelcast/impl/VertxExecutorAdapter.java
@@ -1,0 +1,19 @@
+package io.vertx.spi.cluster.hazelcast.impl;
+
+import io.vertx.core.Context;
+
+import java.util.concurrent.Executor;
+
+final class VertxExecutorAdapter implements Executor {
+
+    private final Context context;
+
+    VertxExecutorAdapter(Context context) {
+        this.context = context;
+    }
+
+    @Override
+    public void execute(Runnable command) {
+        context.runOnContext(aVoid -> command.run());
+    }
+}

--- a/src/main/java/io/vertx/spi/cluster/hazelcast/impl/VoidHandlerCallBackAdapter.java
+++ b/src/main/java/io/vertx/spi/cluster/hazelcast/impl/VoidHandlerCallBackAdapter.java
@@ -1,0 +1,17 @@
+package io.vertx.spi.cluster.hazelcast.impl;
+
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+
+
+final class VoidHandlerCallBackAdapter<T> extends HandlerCallBackAdapter<T> {
+    public VoidHandlerCallBackAdapter(Handler<AsyncResult<Void>> asyncResultHandler) {
+        super((Handler)asyncResultHandler);
+    }
+
+    @Override
+    public void onResponse(T v) {
+        setResult(Future.succeededFuture());
+    }
+}

--- a/src/main/java/io/vertx/spi/cluster/hazelcast/package-info.java
+++ b/src/main/java/io/vertx/spi/cluster/hazelcast/package-info.java
@@ -103,6 +103,17 @@
  * cluster as they do not notify when they leave the cluster and you may loose data, or leave the cluster in an
  * inconsistent state. See https://github.com/vert-x3/vertx-hazelcast/issues/24 for more details.
  *
+ * == Using Hazelcast async methods
+ * Hazelcast's `IMap` and `IAtomicLong` interfaces can be used with async methods returning `ICompletableFuture<V>`,
+ * a natural fit for Vert.x threading model. Even though these interfaces have been available for a long time, they are not
+ * provided by the public `HazelcastInstance` API.
+ *
+ * The default behavior of the `HazelcastClusterManager` is to use the public API. Supplying the option
+ * `-Dvertx.hazelcast.async-api=true` on JVM startup, will indicate that the async Hazelcast API methods will be used to
+ * communicate with the hazelcast cluster. Effectively, this means that when this option is enabled,
+ * execution of all `Counter` operations and `AsyncMap.get`,`AsyncMap.put` and `AsyncMap.remove` operations will
+ * occur in the calling thread (the event loop), instead of a worker thread with `vertx.executeBlocking`.
+ *
  * == Trouble shooting clustering
  *
  * If the default multicast configuration is not working here are some common causes:

--- a/src/test/java/io/vertx/test/core/HazelcastInternalClusterWideMapTest.java
+++ b/src/test/java/io/vertx/test/core/HazelcastInternalClusterWideMapTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2014 Red Hat, Inc.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+
+package io.vertx.test.core;
+
+import io.vertx.core.spi.cluster.ClusterManager;
+import io.vertx.spi.cluster.hazelcast.HazelcastClusterManager;
+
+/**
+ * @author <a href="http://tfox.org">Tim Fox</a>
+ */
+public class HazelcastInternalClusterWideMapTest
+        extends ClusterWideMapTestDifferentNodes {
+
+  static {
+    System.setProperty("hazelcast.wait.seconds.before.join", "0");
+    System.setProperty("hazelcast.local.localAddress", "127.0.0.1");
+    System.setProperty("vertx.hazelcast.async-api", "true");
+  }
+
+  @Override
+  protected ClusterManager getClusterManager() {
+    return new HazelcastClusterManager();
+  }
+
+}

--- a/src/test/java/io/vertx/test/core/HazelcastInternalClusteredSharedCounterTest.java
+++ b/src/test/java/io/vertx/test/core/HazelcastInternalClusteredSharedCounterTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2014 Red Hat, Inc.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+
+package io.vertx.test.core;
+
+import io.vertx.core.spi.cluster.ClusterManager;
+import io.vertx.spi.cluster.hazelcast.HazelcastClusterManager;
+
+/**
+ * @author <a href="http://tfox.org">Tim Fox</a>
+ */
+public class HazelcastInternalClusteredSharedCounterTest
+        extends ClusteredSharedCounterTest {
+
+  static {
+    System.setProperty("hazelcast.wait.seconds.before.join", "0");
+    System.setProperty("hazelcast.local.localAddress", "127.0.0.1");
+    System.setProperty("vertx.hazelcast.async-api", "true");
+  }
+
+  @Override
+  protected ClusterManager getClusterManager() {
+    return new HazelcastClusterManager();
+  }
+
+}

--- a/src/test/java/io/vertx/test/core/ProgrammaticHazelcastClusterManagerTest.java
+++ b/src/test/java/io/vertx/test/core/ProgrammaticHazelcastClusterManagerTest.java
@@ -120,10 +120,11 @@ public class ProgrammaticHazelcastClusterManagerTest extends AsyncTestBase {
     assertTrue(instance1.getLifecycleService().isRunning());
     assertTrue(instance2.getLifecycleService().isRunning());
 
+    waitUntil(() -> vertx1.get() == null  && vertx2.get() == null);
+
     instance1.shutdown();
     instance2.shutdown();
 
-    waitUntil(() -> vertx1.get() == null  && vertx2.get() == null);
   }
 
   @Test


### PR DESCRIPTION
This is an implementation for #28. Here is a summary of changes in this PR:
* A system property must be set (`-Dvertx.hazelcast.async-api=true`) in order to enable usage of `AsyncMap` and `Counter` implementations that rely on `ICompletableFuture` casting.
* `VertxExecutorAdapter` instances are cached within the `Context`
* `HazelcastClusterManager.beforeLeave` has been wrapped in `vertx.executeBlocking`, as it may block.
* Bumped Hazelcast version to latest released (3.6.2)

Looking forward to your feedback! Thanks in advance