### PR TITLE
Using BuiltinClusterDataSerializable for Buffer, JsonObject and JsonArray instead of Refection implementation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -181,5 +181,4 @@
       </build>
     </profile>
   </profiles>
-
 </project>

--- a/src/main/java/io/vertx/spi/cluster/hazelcast/impl/HazelcastAsyncMap.java
+++ b/src/main/java/io/vertx/spi/cluster/hazelcast/impl/HazelcastAsyncMap.java
@@ -16,189 +16,208 @@
 
 package io.vertx.spi.cluster.hazelcast.impl;
 
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+
 import com.hazelcast.core.IMap;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.DataSerializable;
+
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
 import io.vertx.core.shareddata.AsyncMap;
 import io.vertx.core.shareddata.impl.ClusterSerializable;
-
-import java.io.IOException;
-import java.util.concurrent.TimeUnit;
+import io.vertx.spi.cluster.hazelcast.impl.serializable.BufferDataSerializable;
+import io.vertx.spi.cluster.hazelcast.impl.serializable.BuiltinClusterDataSerializable;
+import io.vertx.spi.cluster.hazelcast.impl.serializable.JsonArrayDataSerializable;
+import io.vertx.spi.cluster.hazelcast.impl.serializable.JsonDataSerializable;
 
 public class HazelcastAsyncMap<K, V> implements AsyncMap<K, V> {
 
-  private final Vertx vertx;
-  private final IMap<K, V> map;
+	private final Vertx vertx;
+	private final IMap<K, V> map;
 
-  public HazelcastAsyncMap(Vertx vertx, IMap<K, V> map) {
-    this.vertx = vertx;
-    this.map = map;
-  }
+	public HazelcastAsyncMap(Vertx vertx, IMap<K, V> map) {
+		this.vertx = vertx;
+		this.map = map;
+	}
 
-  @Override
-  public void get(K k, Handler<AsyncResult<V>> asyncResultHandler) {
-    K kk = convertParam(k);
-    vertx.executeBlocking(fut -> fut.complete(convertReturn(map.get(kk))), asyncResultHandler);
-  }
+	@Override
+	public void get(K k, Handler<AsyncResult<V>> asyncResultHandler) {
+		K kk = convertParam(k);
+		vertx.executeBlocking(fut -> fut.complete(convertReturn(map.get(kk))), asyncResultHandler);
+	}
 
-  @Override
-  public void put(K k, V v, Handler<AsyncResult<Void>> completionHandler) {
-    K kk = convertParam(k);
-    V vv = convertParam(v);
-    vertx.executeBlocking(fut -> {
-      map.set(kk, HazelcastServerID.convertServerID(vv));
-      fut.complete();
-    }, completionHandler);
-  }
+	@Override
+	public void put(K k, V v, Handler<AsyncResult<Void>> completionHandler) {
+		K kk = convertParam(k);
+		V vv = convertParam(v);
+		vertx.executeBlocking(fut -> {
+			map.set(kk, HazelcastServerID.convertServerID(vv));
+			fut.complete();
+		}, completionHandler);
+	}
 
-  @Override
-  public void putIfAbsent(K k, V v, Handler<AsyncResult<V>> resultHandler) {
-    K kk = convertParam(k);
-    V vv = convertParam(v);
-    vertx.executeBlocking(fut -> fut.complete(convertReturn(map.putIfAbsent(kk, HazelcastServerID.convertServerID(vv)))),
-                          resultHandler);
-  }
+	@Override
+	public void putIfAbsent(K k, V v, Handler<AsyncResult<V>> resultHandler) {
+		K kk = convertParam(k);
+		V vv = convertParam(v);
+		vertx.executeBlocking(
+				fut -> fut.complete(convertReturn(map.putIfAbsent(kk, HazelcastServerID.convertServerID(vv)))), resultHandler);
+	}
 
-  @Override
-  public void put(K k, V v, long ttl, Handler<AsyncResult<Void>> completionHandler) {
-    K kk = convertParam(k);
-    V vv = convertParam(v);
-    vertx.executeBlocking(fut -> {
-      map.set(kk, HazelcastServerID.convertServerID(vv), ttl, TimeUnit.MILLISECONDS);
-      fut.complete();
-    }, completionHandler);
-  }
+	@Override
+	public void put(K k, V v, long ttl, Handler<AsyncResult<Void>> completionHandler) {
+		K kk = convertParam(k);
+		V vv = convertParam(v);
+		vertx.executeBlocking(fut -> {
+			map.set(kk, HazelcastServerID.convertServerID(vv), ttl, TimeUnit.MILLISECONDS);
+			fut.complete();
+		}, completionHandler);
+	}
 
-  @Override
-  public void putIfAbsent(K k, V v, long ttl, Handler<AsyncResult<V>> resultHandler) {
-    K kk = convertParam(k);
-    V vv = convertParam(v);
-    vertx.executeBlocking(fut -> fut.complete(convertReturn(map.putIfAbsent(kk, HazelcastServerID.convertServerID(vv),
-      ttl, TimeUnit.MILLISECONDS))), resultHandler);
-  }
+	@Override
+	public void putIfAbsent(K k, V v, long ttl, Handler<AsyncResult<V>> resultHandler) {
+		K kk = convertParam(k);
+		V vv = convertParam(v);
+		vertx.executeBlocking(
+				fut -> fut.complete(
+						convertReturn(map.putIfAbsent(kk, HazelcastServerID.convertServerID(vv), ttl, TimeUnit.MILLISECONDS))),
+				resultHandler);
+	}
 
-  @Override
-  public void remove(K k, Handler<AsyncResult<V>> resultHandler) {
-    K kk = convertParam(k);
-    vertx.executeBlocking(fut -> fut.complete(convertReturn(map.remove(kk))), resultHandler);
-  }
+	@Override
+	public void remove(K k, Handler<AsyncResult<V>> resultHandler) {
+		K kk = convertParam(k);
+		vertx.executeBlocking(fut -> fut.complete(convertReturn(map.remove(kk))), resultHandler);
+	}
 
-  @Override
-  public void removeIfPresent(K k, V v, Handler<AsyncResult<Boolean>> resultHandler) {
-    K kk = convertParam(k);
-    V vv = convertParam(v);
-    vertx.executeBlocking(fut -> fut.complete(map.remove(kk, vv)), resultHandler);
-  }
+	@Override
+	public void removeIfPresent(K k, V v, Handler<AsyncResult<Boolean>> resultHandler) {
+		K kk = convertParam(k);
+		V vv = convertParam(v);
+		vertx.executeBlocking(fut -> fut.complete(map.remove(kk, vv)), resultHandler);
+	}
 
-  @Override
-  public void replace(K k, V v, Handler<AsyncResult<V>> resultHandler) {
-    K kk = convertParam(k);
-    V vv = convertParam(v);
-    vertx.executeBlocking(fut -> fut.complete(convertReturn(map.replace(kk, vv))), resultHandler);
-  }
+	@Override
+	public void replace(K k, V v, Handler<AsyncResult<V>> resultHandler) {
+		K kk = convertParam(k);
+		V vv = convertParam(v);
+		vertx.executeBlocking(fut -> fut.complete(convertReturn(map.replace(kk, vv))), resultHandler);
+	}
 
-  @Override
-  public void replaceIfPresent(K k, V oldValue, V newValue, Handler<AsyncResult<Boolean>> resultHandler) {
-    K kk = convertParam(k);
-    V vv = convertParam(oldValue);
-    V vvv = convertParam(newValue);
-    vertx.executeBlocking(fut -> fut.complete(map.replace(kk, vv, vvv)), resultHandler);
-  }
+	@Override
+	public void replaceIfPresent(K k, V oldValue, V newValue, Handler<AsyncResult<Boolean>> resultHandler) {
+		K kk = convertParam(k);
+		V vv = convertParam(oldValue);
+		V vvv = convertParam(newValue);
+		vertx.executeBlocking(fut -> fut.complete(map.replace(kk, vv, vvv)), resultHandler);
+	}
 
-  @Override
-  public void clear(Handler<AsyncResult<Void>> resultHandler) {
-    vertx.executeBlocking(fut -> {
-      map.clear();
-      fut.complete();
-    }, resultHandler);
-  }
+	@Override
+	public void clear(Handler<AsyncResult<Void>> resultHandler) {
+		vertx.executeBlocking(fut -> {
+			map.clear();
+			fut.complete();
+		}, resultHandler);
+	}
 
-  @Override
-  public void size(Handler<AsyncResult<Integer>> resultHandler) {
-    vertx.executeBlocking(fut -> fut.complete(map.size()), resultHandler);
-  }
+	@Override
+	public void size(Handler<AsyncResult<Integer>> resultHandler) {
+		vertx.executeBlocking(fut -> fut.complete(map.size()), resultHandler);
+	}
 
-  @SuppressWarnings("unchecked")
-  private <T> T convertParam(T obj) {
-    if (obj instanceof ClusterSerializable) {
-      ClusterSerializable cobj = (ClusterSerializable)obj;
-      return (T)(new DataSerializableHolder(cobj));
-    } else {
-      return obj;
-    }
-  }
+	@SuppressWarnings("unchecked")
+	private <T> T convertParam(T obj) {
+		if (obj instanceof Buffer) {
+			return (T) (new BufferDataSerializable((Buffer) obj));
+		} else if (obj instanceof JsonObject) {
+			return (T) (new JsonDataSerializable((JsonObject) obj));
+		} else if (obj instanceof JsonArray) {
+			return (T) (new JsonArrayDataSerializable((JsonArray) obj));
+		} else if (obj instanceof ClusterSerializable) {
+			ClusterSerializable cobj = (ClusterSerializable) obj;
+			return (T) (new DataSerializableHolder(cobj));
+		} else {
+			return obj;
+		}
+	}
 
-  @SuppressWarnings("unchecked")
-  private <T> T convertReturn(Object obj) {
-    if (obj instanceof DataSerializableHolder) {
-      DataSerializableHolder cobj = (DataSerializableHolder)obj;
-      return (T)cobj.clusterSerializable();
-    } else {
-      return (T)obj;
-    }
-  }
+	@SuppressWarnings("unchecked")
+	private <T> T convertReturn(Object obj) {
+		if (obj instanceof BuiltinClusterDataSerializable) {
+			return (T) ((BuiltinClusterDataSerializable) obj).clusterSerializable;
+		} else if (obj instanceof DataSerializableHolder) {
+			DataSerializableHolder cobj = (DataSerializableHolder) obj;
+			return (T) cobj.clusterSerializable();
+		} else {
+			return (T) obj;
+		}
+	}
 
-  private static final class DataSerializableHolder implements DataSerializable {
+	private static final class DataSerializableHolder implements DataSerializable {
 
-    private ClusterSerializable clusterSerializable;
+		private ClusterSerializable clusterSerializable;
 
-    public DataSerializableHolder() {
-    }
+		public DataSerializableHolder() {
+		}
 
-    private DataSerializableHolder(ClusterSerializable clusterSerializable) {
-      this.clusterSerializable = clusterSerializable;
-    }
+		private DataSerializableHolder(ClusterSerializable clusterSerializable) {
+			this.clusterSerializable = clusterSerializable;
+		}
 
-    @Override
-    public void writeData(ObjectDataOutput objectDataOutput) throws IOException {
-      objectDataOutput.writeUTF(clusterSerializable.getClass().getName());
-      Buffer buffer = Buffer.buffer();
-      clusterSerializable.writeToBuffer(buffer);
-      byte[] bytes = buffer.getBytes();
-      objectDataOutput.writeInt(bytes.length);
-      objectDataOutput.write(bytes);
-    }
+		@Override
+		public void writeData(ObjectDataOutput objectDataOutput) throws IOException {
+			objectDataOutput.writeUTF(clusterSerializable.getClass().getName());
+			Buffer buffer = Buffer.buffer();
+			clusterSerializable.writeToBuffer(buffer);
+			byte[] bytes = buffer.getBytes();
+			objectDataOutput.writeInt(bytes.length);
+			objectDataOutput.write(bytes);
+		}
 
-    @Override
-    public void readData(ObjectDataInput objectDataInput) throws IOException {
-      String className = objectDataInput.readUTF();
-      int length = objectDataInput.readInt();
-      byte[] bytes = new byte[length];
-      objectDataInput.readFully(bytes);
-      try {
-        Class<?> clazz = Thread.currentThread().getContextClassLoader().loadClass(className);
-        clusterSerializable = (ClusterSerializable)clazz.newInstance();
-        clusterSerializable.readFromBuffer(0, Buffer.buffer(bytes));
-      } catch (Exception e) {
-        throw new IllegalStateException("Failed to load class " + e.getMessage(), e);
-      }
-    }
+		@Override
+		public void readData(ObjectDataInput objectDataInput) throws IOException {
+			String className = objectDataInput.readUTF();
+			int length = objectDataInput.readInt();
+			byte[] bytes = new byte[length];
+			objectDataInput.readFully(bytes);
+			try {
+				Class<?> clazz = Thread.currentThread().getContextClassLoader().loadClass(className);
+				clusterSerializable = (ClusterSerializable) clazz.newInstance();
+				clusterSerializable.readFromBuffer(0, Buffer.buffer(bytes));				
+			} catch (Exception e) {
+				throw new IllegalStateException("Failed to load class " + e.getMessage(), e);
+			}
+		}
 
-    @Override
-    public boolean equals(Object o) {
-      if (this == o) return true;
-      if (!(o instanceof DataSerializableHolder)) return false;
-      DataSerializableHolder that = (DataSerializableHolder) o;
-      if (clusterSerializable != null ? !clusterSerializable.equals(that.clusterSerializable) : that.clusterSerializable != null) {
-        return false;
-      }
-      return true;
-    }
+		@Override
+		public boolean equals(Object o) {
+			if (this == o)
+				return true;
+			if (!(o instanceof DataSerializableHolder))
+				return false;
+			DataSerializableHolder that = (DataSerializableHolder) o;
+			if (clusterSerializable != null ? !clusterSerializable.equals(that.clusterSerializable)
+					: that.clusterSerializable != null) {
+				return false;
+			}
+			return true;
+		}
 
-    @Override
-    public int hashCode() {
-      return clusterSerializable != null ? clusterSerializable.hashCode() : 0;
-    }
+		@Override
+		public int hashCode() {
+			return clusterSerializable != null ? clusterSerializable.hashCode() : 0;
+		}
 
-    public ClusterSerializable clusterSerializable() {
-      return clusterSerializable;
-    }
-  }
-
+		public ClusterSerializable clusterSerializable() {
+			return clusterSerializable;
+		}
+	}
 
 }

--- a/src/main/java/io/vertx/spi/cluster/hazelcast/impl/serializable/BufferDataSerializable.java
+++ b/src/main/java/io/vertx/spi/cluster/hazelcast/impl/serializable/BufferDataSerializable.java
@@ -1,0 +1,25 @@
+package io.vertx.spi.cluster.hazelcast.impl.serializable;
+
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.shareddata.impl.ClusterSerializable;
+
+public class BufferDataSerializable extends BuiltinClusterDataSerializable {
+	
+	public BufferDataSerializable(Buffer buff){
+		super(buff);
+	}
+	public BufferDataSerializable(){
+		
+	}
+
+	@Override
+	public int getId() {
+		return 0;
+	}
+
+	@Override
+	protected ClusterSerializable newInstance(byte[] bytes) {
+		return Buffer.buffer(bytes);
+	}
+
+}

--- a/src/main/java/io/vertx/spi/cluster/hazelcast/impl/serializable/BuiltinClusterDataSerializable.java
+++ b/src/main/java/io/vertx/spi/cluster/hazelcast/impl/serializable/BuiltinClusterDataSerializable.java
@@ -1,0 +1,44 @@
+package io.vertx.spi.cluster.hazelcast.impl.serializable;
+
+import java.io.IOException;
+
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.shareddata.impl.ClusterSerializable;
+
+public abstract class BuiltinClusterDataSerializable implements IdentifiedDataSerializable {
+	
+	public ClusterSerializable clusterSerializable;
+	
+	public BuiltinClusterDataSerializable(ClusterSerializable clusterSerializable){
+		this.clusterSerializable = clusterSerializable;
+	}
+	public BuiltinClusterDataSerializable(){
+		
+	}
+	@Override
+	public int getFactoryId() {
+		return VertxDataSerializerHook.FACTORY_ID;
+	}
+	@Override
+	public void writeData(ObjectDataOutput objectDataOutput) throws IOException {
+		objectDataOutput.writeUTF(clusterSerializable.getClass().getName());
+    Buffer buffer = Buffer.buffer();
+    clusterSerializable.writeToBuffer(buffer);
+    byte[] bytes = buffer.getBytes();
+    objectDataOutput.writeInt(bytes.length);
+    objectDataOutput.write(bytes);
+	}	
+	@Override
+	public void readData(ObjectDataInput objectDataInput) throws IOException {
+    int length = objectDataInput.readInt();
+    byte[] bytes = new byte[length];
+    objectDataInput.readFully(bytes);
+    clusterSerializable = newInstance(bytes);
+	}
+	protected abstract ClusterSerializable newInstance(byte[] bytes);
+
+}

--- a/src/main/java/io/vertx/spi/cluster/hazelcast/impl/serializable/JsonArrayDataSerializable.java
+++ b/src/main/java/io/vertx/spi/cluster/hazelcast/impl/serializable/JsonArrayDataSerializable.java
@@ -1,0 +1,25 @@
+package io.vertx.spi.cluster.hazelcast.impl.serializable;
+
+import java.nio.charset.StandardCharsets;
+
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.shareddata.impl.ClusterSerializable;
+
+public class JsonArrayDataSerializable extends BuiltinClusterDataSerializable {
+	public JsonArrayDataSerializable(){
+		
+	}
+	public JsonArrayDataSerializable(JsonArray obj){
+		super(obj);
+	}
+	@Override
+	public int getId() {
+		return 2;
+	}
+
+	@Override
+	protected ClusterSerializable newInstance(byte[] bytes) {
+		return new JsonArray(new String(bytes,StandardCharsets.UTF_8));
+	}
+
+}

--- a/src/main/java/io/vertx/spi/cluster/hazelcast/impl/serializable/JsonDataSerializable.java
+++ b/src/main/java/io/vertx/spi/cluster/hazelcast/impl/serializable/JsonDataSerializable.java
@@ -1,0 +1,27 @@
+package io.vertx.spi.cluster.hazelcast.impl.serializable;
+
+import java.nio.charset.StandardCharsets;
+
+import io.vertx.core.json.JsonObject;
+import io.vertx.core.shareddata.impl.ClusterSerializable;
+
+public class JsonDataSerializable extends BuiltinClusterDataSerializable {
+
+	public JsonDataSerializable(){
+		
+	}
+	
+	public JsonDataSerializable(JsonObject obj){
+		super(obj);
+	}
+	@Override
+	public int getId() {
+		return 1;
+	}
+
+	@Override
+	protected ClusterSerializable newInstance(byte[] bytes) {
+		return new JsonObject(new String(bytes,StandardCharsets.UTF_8));
+	}
+
+}

--- a/src/main/java/io/vertx/spi/cluster/hazelcast/impl/serializable/VertxDataSerializableFactory.java
+++ b/src/main/java/io/vertx/spi/cluster/hazelcast/impl/serializable/VertxDataSerializableFactory.java
@@ -1,0 +1,19 @@
+package io.vertx.spi.cluster.hazelcast.impl.serializable;
+
+import com.hazelcast.nio.serialization.DataSerializableFactory;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+
+public class VertxDataSerializableFactory implements DataSerializableFactory {
+	@Override
+	public IdentifiedDataSerializable create(int id) {
+		switch (id) {
+		case 0:
+			return new BufferDataSerializable();
+		case 1:
+			return new JsonDataSerializable();
+		default:
+			return new JsonArrayDataSerializable();
+		}
+	}
+
+}

--- a/src/main/java/io/vertx/spi/cluster/hazelcast/impl/serializable/VertxDataSerializerHook.java
+++ b/src/main/java/io/vertx/spi/cluster/hazelcast/impl/serializable/VertxDataSerializerHook.java
@@ -1,0 +1,17 @@
+package io.vertx.spi.cluster.hazelcast.impl.serializable;
+
+import com.hazelcast.nio.serialization.DataSerializableFactory;
+
+public class VertxDataSerializerHook implements com.hazelcast.internal.serialization.DataSerializerHook {
+	public final static int FACTORY_ID = 2906;
+	@Override
+	public int getFactoryId() {
+		return FACTORY_ID;
+	}
+
+	@Override
+	public DataSerializableFactory createFactory() {
+		return new VertxDataSerializableFactory();
+	}
+
+}

--- a/src/main/resources/META-INF/services/com.hazelcast.DataSerializerHook
+++ b/src/main/resources/META-INF/services/com.hazelcast.DataSerializerHook
@@ -1,0 +1,1 @@
+io.vertx.spi.cluster.hazelcast.impl.serializable.VertxDataSerializerHook


### PR DESCRIPTION
Almost message send via vertx cluster using JsonObject, JsonArray & Buffer.
Implement using BuiltinClusterDataSerializable will improve performance of ~~eventbus~~ AsyncMap
Here is a summary of changes in this PR:
- BufferDataSerializable
- JsonDataSerializable
- JsonArraySerializable
