### PR TITLE
Documentation update on hazelcast configuration

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -7,8 +7,8 @@ This is a cluster manager implementation for Vert.x that uses http://hazelcast.c
 It is the default cluster manager in the Vert.x distribution, but it can be replaced with another implementation as Vert.x
 cluster managers are pluggable.
 
-Please see the in source asciidoc documentation or the main documentation on the web-site for a full description
+Please see the in-source asciidoc documentation or the main documentation on the web-site for a full description
 of this component:
 
-* Web-site docs
+* link:http://vertx.io/docs/vertx-hazelcast/java/[web-site docs]
 * link:src/main/asciidoc/java/index.adoc[in-source docs]

--- a/src/main/asciidoc/java/index.adoc
+++ b/src/main/asciidoc/java/index.adoc
@@ -63,7 +63,7 @@ which is packaged inside the jar.
 If you want to override this configuration you can provide a file called `cluster.xml` on your classpath and this
 will be used instead. If you want to embed the `cluster.xml` file in a fat jar, it must be located at the root of the
 fat jar. If it's an external file, the **directory** containing the file must be added to the classpath. For
-example, if you are using the _launcher_ class from vert.x, the classpath enhancement can be done as follows:
+example, if you are using the _launcher_ class from Vert.x, the classpath enhancement can be done as follows:
 
 [source]
 ----
@@ -77,6 +77,9 @@ java -jar ... -cp conf -cluster
 
 The xml file is a Hazelcast configuration file and is described in detail in the documentation on the Hazelcast
 web-site.
+
+**Note** Configuration of Hazelcast using the http://docs.hazelcast.org/docs/3.6.1/manual/html-single/index.html#configuring-hazelcast[`-Dhazelcast.config`]
+system property is not supported by Vert.x and should not be used.
 
 You can also specify configuration programmatically if embedding:
 
@@ -202,7 +205,7 @@ documentation.
 
 When trouble-shooting clustering issues with Hazelcast it's often useful to get some logging output from Hazelcast
 to see if it's forming a cluster properly. You can do this (when using the default JUL logging) by adding a file
-called `vertx-default-jul-logging.properties` on your classpath. This is a standard java.util.loging (JUL)
+called `vertx-default-jul-logging.properties` on your classpath. This is a standard java.util.logging (JUL)
 configuration file. Inside it set:
 
 ----

--- a/src/main/java/io/vertx/spi/cluster/hazelcast/package-info.java
+++ b/src/main/java/io/vertx/spi/cluster/hazelcast/package-info.java
@@ -54,7 +54,7 @@
  * If you want to override this configuration you can provide a file called `cluster.xml` on your classpath and this
  * will be used instead. If you want to embed the `cluster.xml` file in a fat jar, it must be located at the root of the
  * fat jar. If it's an external file, the **directory** containing the file must be added to the classpath. For
- * example, if you are using the _launcher_ class from vert.x, the classpath enhancement can be done as follows:
+ * example, if you are using the _launcher_ class from Vert.x, the classpath enhancement can be done as follows:
  *
  * [source]
  * ----
@@ -68,6 +68,9 @@
  *
  * The xml file is a Hazelcast configuration file and is described in detail in the documentation on the Hazelcast
  * web-site.
+ *
+ * **Note** Configuration of Hazelcast using the http://docs.hazelcast.org/docs/3.6.1/manual/html-single/index.html#configuring-hazelcast[`-Dhazelcast.config`]
+ * system property is not supported by Vert.x and should not be used.
  *
  * You can also specify configuration programmatically if embedding:
  *


### PR DESCRIPTION
Update to the documentation related to [discussion](https://groups.google.com/forum/#!topic/vertx/WSa6NDmdXjw) on using `-Dhazelcast.config` to supply configuration file. While this does _seem_ to work, the `HazelcastClusterManager` will be improperly initialized.

When reading Hazelcast documentation on configuration the instructions might lead one to use the system property, so Vert.x docs must explicitly mention not to do this.

(I will file a separate issue on adding support for `hazelcast.config` in a future release, unless there is specific reason not to support it)