### PR TITLE
Support configuration using 'hazelcast.config' system property

### DIFF
--- a/src/main/asciidoc/java/index.adoc
+++ b/src/main/asciidoc/java/index.adoc
@@ -75,6 +75,20 @@ vertx run MyVerticle -cp . -cluster
 java -jar ... -cp conf -cluster
 ----
 
+Another way to override the configuration is by providing the system property `hazelcast.config` with a location:
+
+[source]
+----
+# Use a cluster configuration located in an external file
+java -Dhazelcast.config=./config/my-cluster-config.xml -jar ... -cluster
+
+# Or use a custom configuration from the classpath
+java -Dhazelcast.config=classpath:my/package/config/my-cluster-config.xml -jar ... -cluster
+----
+
+The `hazelcast.config` system property, when present, overrides any `cluster.xml` on the classpath, but if loading
+from this system property fails, then loading falls back to either `cluster.xml` or the Hazelcast default configuration.
+
 The xml file is a Hazelcast configuration file and is described in detail in the documentation on the Hazelcast
 web-site.
 
@@ -205,7 +219,7 @@ documentation.
 
 When trouble-shooting clustering issues with Hazelcast it's often useful to get some logging output from Hazelcast
 to see if it's forming a cluster properly. You can do this (when using the default JUL logging) by adding a file
-called `vertx-default-jul-logging.properties` on your classpath. This is a standard java.util.logging (JUL)
+called `vertx-default-jul-logging.properties` on your classpath. This is a standard java.util.loging (JUL)
 configuration file. Inside it set:
 
 ----

--- a/src/main/asciidoc/java/index.adoc
+++ b/src/main/asciidoc/java/index.adoc
@@ -219,7 +219,7 @@ documentation.
 
 When trouble-shooting clustering issues with Hazelcast it's often useful to get some logging output from Hazelcast
 to see if it's forming a cluster properly. You can do this (when using the default JUL logging) by adding a file
-called `vertx-default-jul-logging.properties` on your classpath. This is a standard java.util.loging (JUL)
+called `vertx-default-jul-logging.properties` on your classpath. This is a standard java.util.logging (JUL)
 configuration file. Inside it set:
 
 ----

--- a/src/main/asciidoc/java/index.adoc
+++ b/src/main/asciidoc/java/index.adoc
@@ -92,9 +92,6 @@ from this system property fails, then loading falls back to either `cluster.xml`
 The xml file is a Hazelcast configuration file and is described in detail in the documentation on the Hazelcast
 web-site.
 
-**Note** Configuration of Hazelcast using the http://docs.hazelcast.org/docs/3.6.1/manual/html-single/index.html#configuring-hazelcast[`-Dhazelcast.config`]
-system property is not supported by Vert.x and should not be used.
-
 You can also specify configuration programmatically if embedding:
 
 [source,java]

--- a/src/main/java/io/vertx/spi/cluster/hazelcast/HazelcastClusterManager.java
+++ b/src/main/java/io/vertx/spi/cluster/hazelcast/HazelcastClusterManager.java
@@ -34,9 +34,7 @@ import io.vertx.core.spi.cluster.NodeListener;
 import io.vertx.spi.cluster.hazelcast.impl.HazelcastAsyncMap;
 import io.vertx.spi.cluster.hazelcast.impl.HazelcastAsyncMultiMap;
 
-import java.io.BufferedInputStream;
-import java.io.IOException;
-import java.io.InputStream;
+import java.io.*;
 import java.util.*;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -109,9 +107,9 @@ public class HazelcastClusterManager implements ExtendedClusterManager, Membersh
         }
 
         if (conf == null) {
-          conf = loadConfigFromClasspath();
+          conf = loadConfig();
           if (conf == null) {
-            log.warn("Cannot find cluster configuration on classpath and none specified programmatically. Using default hazelcast configuration");
+            log.warn("Cannot find cluster configuration on 'hazelcast.config' system property, on the classpath, or specified programmatically. Using default hazelcast configuration");
           }
         }
         hazelcast = Hazelcast.newHazelcastInstance(conf);
@@ -264,15 +262,42 @@ public class HazelcastClusterManager implements ExtendedClusterManager, Membersh
   }
 
   private InputStream getConfigStream() {
-    ClassLoader ctxClsLoader = Thread.currentThread().getContextClassLoader();
+    InputStream is = getConfigStreamFromSystemProperty();
+    if (is == null) {
+      is = getConfigStreamFromClasspath(CONFIG_FILE, DEFAULT_CONFIG_FILE);
+    }
+    return is;
+  }
+
+  private InputStream getConfigStreamFromSystemProperty() {
+    String configProp = System.getProperty("hazelcast.config");
     InputStream is = null;
+    if (configProp != null) {
+      if (configProp.startsWith("classpath:")) {
+        return getConfigStreamFromClasspath(configProp.substring("classpath:".length()), CONFIG_FILE);
+      }
+      File cfgFile = new File(configProp);
+      if (cfgFile.exists()) {
+        try {
+          is = new FileInputStream(cfgFile);
+        } catch (FileNotFoundException ex) {
+          log.warn("Failed to open file '" + configProp + "' defined in 'hazelcast.config'. Continuing classpath search for " + CONFIG_FILE);
+        }
+      }
+    }
+    return is;
+  }
+
+  private InputStream getConfigStreamFromClasspath(String configFile, String defaultConfig) {
+    InputStream is = null;
+    ClassLoader ctxClsLoader = Thread.currentThread().getContextClassLoader();
     if (ctxClsLoader != null) {
-      is = ctxClsLoader.getResourceAsStream(CONFIG_FILE);
+      is = ctxClsLoader.getResourceAsStream(configFile);
     }
     if (is == null) {
-      is = getClass().getClassLoader().getResourceAsStream(CONFIG_FILE);
+      is = getClass().getClassLoader().getResourceAsStream(configFile);
       if (is == null) {
-        is = getClass().getClassLoader().getResourceAsStream(DEFAULT_CONFIG_FILE);
+        is = getClass().getClassLoader().getResourceAsStream(defaultConfig);
       }
     }
     return is;
@@ -294,7 +319,7 @@ public class HazelcastClusterManager implements ExtendedClusterManager, Membersh
     this.conf = config;
   }
 
-  public Config loadConfigFromClasspath() {
+  public Config loadConfig() {
     Config cfg = null;
     try (InputStream is = getConfigStream();
          InputStream bis = new BufferedInputStream(is)) {

--- a/src/main/java/io/vertx/spi/cluster/hazelcast/package-info.java
+++ b/src/main/java/io/vertx/spi/cluster/hazelcast/package-info.java
@@ -83,9 +83,6 @@
  * The xml file is a Hazelcast configuration file and is described in detail in the documentation on the Hazelcast
  * web-site.
  *
- * **Note** Configuration of Hazelcast using the http://docs.hazelcast.org/docs/3.6.1/manual/html-single/index.html#configuring-hazelcast[`-Dhazelcast.config`]
- * system property is not supported by Vert.x and should not be used.
- *
  * You can also specify configuration programmatically if embedding:
  *
  * [source,$lang]

--- a/src/main/java/io/vertx/spi/cluster/hazelcast/package-info.java
+++ b/src/main/java/io/vertx/spi/cluster/hazelcast/package-info.java
@@ -188,7 +188,7 @@
  *
  * When trouble-shooting clustering issues with Hazelcast it's often useful to get some logging output from Hazelcast
  * to see if it's forming a cluster properly. You can do this (when using the default JUL logging) by adding a file
- * called `vertx-default-jul-logging.properties` on your classpath. This is a standard java.util.loging (JUL)
+ * called `vertx-default-jul-logging.properties` on your classpath. This is a standard java.util.logging (JUL)
  * configuration file. Inside it set:
  *
  * ----

--- a/src/main/java/io/vertx/spi/cluster/hazelcast/package-info.java
+++ b/src/main/java/io/vertx/spi/cluster/hazelcast/package-info.java
@@ -66,6 +66,20 @@
  * java -jar ... -cp conf -cluster
  * ----
  *
+ * Another way to override the configuration is by providing the system property `hazelcast.config` with a location:
+ *
+ * [source]
+ * ----
+ * # Use a cluster configuration located in an external file
+ * java -Dhazelcast.config=./config/my-cluster-config.xml -jar ... -cluster
+ *
+ * # Or use a custom configuration from the classpath
+ * java -Dhazelcast.config=classpath:my/package/config/my-cluster-config.xml -jar ... -cluster
+ * ----
+ *
+ * The `hazelcast.config` system property, when present, overrides any `cluster.xml` on the classpath, but if loading
+ * from this system property fails, then loading falls back to either `cluster.xml` or the Hazelcast default configuration.
+ *
  * The xml file is a Hazelcast configuration file and is described in detail in the documentation on the Hazelcast
  * web-site.
  *


### PR DESCRIPTION
This PR addresses issue #36 
It is implemented such that the system property, when it is present and can be loaded, overrides all other config locations. If loading from system property is not possible, then loading commences as before (looking for 'cluster.xml' on the classpath).