### PR TITLE
Do not fail getLockWithTimeout before timeout

### DIFF
--- a/src/main/asciidoc/java/index.adoc
+++ b/src/main/asciidoc/java/index.adoc
@@ -10,7 +10,7 @@ cluster managers are pluggable.  This implementation is packaged inside:
 <dependency>
   <groupId>io.vertx</groupId>
   <artifactId>vertx-hazelcast</artifactId>
-  <version>3.3.2</version>
+  <version>3.4.0-SNAPSHOT</version>
 </dependency>
 ----
 
@@ -277,7 +277,7 @@ In this later case, you would need in Maven:
 <dependency>
   <groupId>io.vertx</groupId>
   <artifactId>vertx-hazelcast</artifactId>
-  <version>3.3.2</version>
+  <version>3.4.0-SNAPSHOT</version>
 </dependency>
 ----
 
@@ -288,7 +288,7 @@ On Gradle, you can achieve the same overloading using:
 [source]
 ----
 dependencies {
- compile ("io.vertx:vertx-hazelcast:3.3.2"){
+ compile ("io.vertx:vertx-hazelcast:3.4.0-SNAPSHOT"){
    exclude group: 'com.hazelcast', module: 'hazelcast'
  }
  compile "com.hazelcast:hazelcast:ENTER_YOUR_VERSION_HERE"

--- a/src/test/java/io/vertx/test/core/HazelcastClusteredAsynchronousLockTest.java
+++ b/src/test/java/io/vertx/test/core/HazelcastClusteredAsynchronousLockTest.java
@@ -18,6 +18,7 @@ package io.vertx.test.core;
 
 import io.vertx.core.spi.cluster.ClusterManager;
 import io.vertx.spi.cluster.hazelcast.HazelcastClusterManager;
+import org.junit.Test;
 
 /**
  * @author <a href="http://tfox.org">Tim Fox</a>
@@ -34,4 +35,15 @@ public class HazelcastClusteredAsynchronousLockTest extends ClusteredAsynchronou
     return new HazelcastClusterManager();
   }
 
+  @Override
+  @Test
+  public void testLockReleasedForClosedNode() throws Exception {
+    super.testLockReleasedForClosedNode();
+  }
+
+  @Override
+  @Test
+  public void testLockReleasedForKilledNode() throws Exception {
+    super.testLockReleasedForKilledNode();
+  }
 }


### PR DESCRIPTION
When a node leaves the cluster, the thread invoking tryAcquire may be interrupted before timeout has expired. So we should check if there is some time remaining and try again.