### PR TITLE
Changes the subs map handling for better consistency

### DIFF
--- a/src/main/java/io/vertx/spi/cluster/hazelcast/HazelcastClusterManager.java
+++ b/src/main/java/io/vertx/spi/cluster/hazelcast/HazelcastClusterManager.java
@@ -25,6 +25,8 @@ import com.hazelcast.core.IAtomicLong;
 import com.hazelcast.core.ILock;
 import com.hazelcast.core.IMap;
 import com.hazelcast.core.ISemaphore;
+import com.hazelcast.core.LifecycleEvent;
+import com.hazelcast.core.LifecycleListener;
 import com.hazelcast.core.Member;
 import com.hazelcast.core.MemberAttributeEvent;
 import com.hazelcast.core.MembershipEvent;
@@ -53,10 +55,13 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.WeakHashMap;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
 
@@ -67,7 +72,7 @@ import static java.util.concurrent.TimeUnit.*;
  *
  * @author <a href="http://tfox.org">Tim Fox</a>
  */
-public class HazelcastClusterManager implements ExtendedClusterManager, MembershipListener {
+public class HazelcastClusterManager implements ExtendedClusterManager, MembershipListener, LifecycleListener {
 
   private static final Logger log = LoggerFactory.getLogger(HazelcastClusterManager.class);
 
@@ -103,7 +108,11 @@ public class HazelcastClusterManager implements ExtendedClusterManager, Membersh
   private HazelcastInstance hazelcast;
   private String nodeID;
   private String membershipListenerId;
+  private String lifecycleListenerId;
   private boolean customHazelcastCluster;
+  private Set<Member> members = new HashSet<>();
+  // Guarded by this
+  private Set<HazelcastAsyncMultiMap> multimaps = Collections.newSetFromMap(new WeakHashMap<>(1));
 
   private NodeListener nodeListener;
   private volatile boolean active;
@@ -145,6 +154,7 @@ public class HazelcastClusterManager implements ExtendedClusterManager, Membersh
         if (customHazelcastCluster) {
           nodeID = hazelcast.getLocalEndpoint().getUuid();
           membershipListenerId = hazelcast.getCluster().addMembershipListener(this);
+          lifecycleListenerId = hazelcast.getLifecycleService().addLifecycleListener(this);
           fut.complete();
           return;
         }
@@ -159,6 +169,7 @@ public class HazelcastClusterManager implements ExtendedClusterManager, Membersh
         hazelcast = Hazelcast.newHazelcastInstance(conf);
         nodeID = hazelcast.getLocalEndpoint().getUuid();
         membershipListenerId = hazelcast.getCluster().addMembershipListener(this);
+        lifecycleListenerId = hazelcast.getLifecycleService().addLifecycleListener(this);
         fut.complete();
       }
     }, resultHandler);
@@ -178,7 +189,11 @@ public class HazelcastClusterManager implements ExtendedClusterManager, Membersh
   public <K, V> void getAsyncMultiMap(String name, Handler<AsyncResult<AsyncMultiMap<K, V>>> resultHandler) {
     vertx.executeBlocking(fut -> {
       com.hazelcast.core.MultiMap<K, V> multiMap = hazelcast.getMultiMap(name);
-      fut.complete(new HazelcastAsyncMultiMap<>(vertx, multiMap));
+      HazelcastAsyncMultiMap<K, V> asyncMultiMap = new HazelcastAsyncMultiMap<>(vertx, multiMap);
+      synchronized (this) {
+        multimaps.add(asyncMultiMap);
+      }
+      fut.complete(asyncMultiMap);
     }, resultHandler);
   }
 
@@ -262,6 +277,8 @@ public class HazelcastClusterManager implements ExtendedClusterManager, Membersh
             if (!left) {
               log.warn("No membership listener");
             }
+            hazelcast.getLifecycleService().removeLifecycleListener(lifecycleListenerId);
+
             // Do not shutdown the cluster if we are not the owner.
             while (!customHazelcastCluster && hazelcast.getLifecycleService().isRunning()) {
               try {
@@ -292,8 +309,10 @@ public class HazelcastClusterManager implements ExtendedClusterManager, Membersh
       return;
     }
     try {
+      multimaps.forEach(HazelcastAsyncMultiMap::clearCache);
       if (nodeListener != null) {
         Member member = membershipEvent.getMember();
+        members.add(member);
         nodeListener.nodeAdded(member.getUuid());
       }
     } catch (Throwable t) {
@@ -307,12 +326,37 @@ public class HazelcastClusterManager implements ExtendedClusterManager, Membersh
       return;
     }
     try {
+      multimaps.forEach(HazelcastAsyncMultiMap::clearCache);
       if (nodeListener != null) {
         Member member = membershipEvent.getMember();
+        members.remove(member);
         nodeListener.nodeLeft(member.getUuid());
       }
     } catch (Throwable t) {
       log.error("Failed to handle memberRemoved", t);
+    }
+  }
+
+  @Override
+  public synchronized void stateChanged(LifecycleEvent lifecycleEvent) {
+    if (!active) {
+      return;
+    }
+    multimaps.forEach(HazelcastAsyncMultiMap::clearCache);
+    // Safeguard to make sure members list is OK after a partition merge
+    if(lifecycleEvent.getState() == LifecycleEvent.LifecycleState.MERGED) {
+      final Set<Member> currentMembers = hazelcast.getCluster().getMembers();
+      Set<Member> newMembers = new HashSet<>(currentMembers);
+      newMembers.removeAll(members);
+      Set<Member> removedMembers = new HashSet<>(members);
+      removedMembers.removeAll(currentMembers);
+      for(Member m : newMembers) {
+        nodeListener.nodeAdded(m.getUuid());
+      }
+      for(Member m : removedMembers) {
+        nodeListener.nodeLeft(m.getUuid());
+      }
+      members.retainAll(currentMembers);
     }
   }
 

--- a/src/main/java/io/vertx/spi/cluster/hazelcast/impl/HazelcastAsyncMultiMap.java
+++ b/src/main/java/io/vertx/spi/cluster/hazelcast/impl/HazelcastAsyncMultiMap.java
@@ -33,6 +33,7 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Predicate;
 
 /**
  * @author <a href="http://tfox.org">Tim Fox</a>
@@ -66,10 +67,15 @@ public class HazelcastAsyncMultiMap<K, V> implements AsyncMultiMap<K, V>, EntryL
 
   @Override
   public void removeAllForValue(V val, Handler<AsyncResult<Void>> completionHandler) {
+    removeAll(val::equals, completionHandler);
+  }
+
+  @Override
+  public void removeAll(Predicate<V> p, Handler<AsyncResult<Void>> completionHandler) {
     vertx.executeBlocking(fut -> {
       for (Map.Entry<K, V> entry : map.entrySet()) {
         V v = entry.getValue();
-        if (val.equals(v)) {
+        if (p.test(v)) {
           map.remove(entry.getKey(), v);
         }
       }
@@ -80,7 +86,7 @@ public class HazelcastAsyncMultiMap<K, V> implements AsyncMultiMap<K, V>, EntryL
   @Override
   public void add(K k, V v, Handler<AsyncResult<Void>> completionHandler) {
     vertx.executeBlocking(fut -> {
-      map.put(k, HazelcastServerID.convertServerID(v));
+      map.put(k, HazelcastClusterNodeInfo.convertClusterNodeInfo(v));
       fut.complete();
     }, completionHandler);
   }
@@ -120,7 +126,7 @@ public class HazelcastAsyncMultiMap<K, V> implements AsyncMultiMap<K, V>, EntryL
 
   @Override
   public void remove(K k, V v, Handler<AsyncResult<Boolean>> completionHandler) {
-    vertx.executeBlocking(fut -> fut.complete(map.remove(k, HazelcastServerID.convertServerID(v))), completionHandler);
+    vertx.executeBlocking(fut -> fut.complete(map.remove(k, HazelcastClusterNodeInfo.convertClusterNodeInfo(v))), completionHandler);
   }
 
   @Override
@@ -175,12 +181,15 @@ public class HazelcastAsyncMultiMap<K, V> implements AsyncMultiMap<K, V>, EntryL
 
   @Override
   public void mapEvicted(MapEvent mapEvent) {
-    cache.clear();
+    clearCache();
   }
 
   @Override
   public void mapCleared(MapEvent mapEvent) {
-    cache.clear();
+    clearCache();
   }
 
+  public void clearCache() {
+    cache.clear();
+  }
 }

--- a/src/main/java/io/vertx/spi/cluster/hazelcast/impl/HazelcastClusterNodeInfo.java
+++ b/src/main/java/io/vertx/spi/cluster/hazelcast/impl/HazelcastClusterNodeInfo.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2017 Red Hat, Inc.
+ *
+ * Red Hat licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.vertx.spi.cluster.hazelcast.impl;
+
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.DataSerializable;
+import io.vertx.core.eventbus.impl.clustered.ClusterNodeInfo;
+
+import java.io.IOException;
+
+/**
+ * @author Thomas Segismont
+ */
+public class HazelcastClusterNodeInfo extends ClusterNodeInfo implements DataSerializable {
+
+  public HazelcastClusterNodeInfo() {
+  }
+
+  public HazelcastClusterNodeInfo(ClusterNodeInfo clusterNodeInfo) {
+    super(clusterNodeInfo.nodeId, clusterNodeInfo.host, clusterNodeInfo.port);
+  }
+
+  @Override
+  public void writeData(ObjectDataOutput dataOutput) throws IOException {
+    dataOutput.writeUTF(nodeId);
+    dataOutput.writeUTF(host);
+    dataOutput.writeInt(port);
+  }
+
+  @Override
+  public void readData(ObjectDataInput dataInput) throws IOException {
+    nodeId = dataInput.readUTF();
+    host = dataInput.readUTF();
+    port = dataInput.readInt();
+  }
+
+  // We replace any ClusterNodeInfo instances with HazelcastClusterNodeInfo
+  // This allows them to be serialized more optimally using DataSerializable
+  @SuppressWarnings("unchecked")
+  public static <V> V convertClusterNodeInfo(V val) {
+    if (val.getClass() == ClusterNodeInfo.class) {
+      ClusterNodeInfo cni = (ClusterNodeInfo) val;
+      HazelcastClusterNodeInfo hcni = new HazelcastClusterNodeInfo(cni);
+      return (V) hcni;
+    } else {
+      return val;
+    }
+  }
+}


### PR DESCRIPTION
This PR is related to https://github.com/eclipse/vert.x/pull/1735. In our tests, Hazelcast 3.7.x behaves more robustly than 3.6.x after a cluster partition when running in TCP mode rather than multicast mode. 3.6 can end up with a single node partition never rejoining the cluster when multicast is not used. We also add an extra member check after partition merge as an extra safety measure (inspired by the infinispan cluster manager).
Finally, as it relates to the work done in the above PR, it adds implementation for a new method in AsyncMultiMap.
