### PR TITLE
Revert "This fixes #55 vertx-hazelcast isn't OSGi friendly"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -150,28 +150,6 @@
         </executions>
       </plugin>
 
-      <plugin>
-        <groupId>biz.aQute.bnd</groupId>
-        <artifactId>bnd-maven-plugin</artifactId>
-        <version>3.2.0</version>
-
-        <executions>
-          <execution>
-            <id>default-bnd-process</id>
-            <goals>
-              <goal>bnd-process</goal>
-            </goals>
-          </execution>
-        </executions>
-        <configuration>
-          <bnd><![CDATA[
-          Import-Package: \
-	          *
-	        -exportcontents: !*impl, !examples, *
-          ]]></bnd>
-        </configuration>
-      </plugin>
-
     </plugins>
   </build>
 


### PR DESCRIPTION
Reverts vert-x3/vertx-hazelcast#56

The build fails with:

```
[INFO] --- bnd-maven-plugin:3.2.0:bnd-process (default-bnd-process) @ vertx-hazelcast ---
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 14.988s
[INFO] Finished at: Thu Feb 16 00:40:36 GMT 2017
[INFO] Final Memory: 22M/274M
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal biz.aQute.bnd:bnd-maven-plugin:3.2.0:bnd-process (default-bnd-process) on project vertx-hazelcast: Execution default-bnd-process of goal biz.aQute.bnd:bnd-maven-plugin:3.2.0:bnd-process failed: A required class was missing while executing biz.aQute.bnd:bnd-maven-plugin:3.2.0:bnd-process: org/slf4j/LoggerFactory
[ERROR] -----------------------------------------------------
[ERROR] realm =    plugin>biz.aQute.bnd:bnd-maven-plugin:3.2.0
[ERROR] strategy = org.codehaus.plexus.classworlds.strategy.SelfFirstStrategy
[ERROR] urls[0] = file:/home/jenkins/.m2/repository/biz/aQute/bnd/bnd-maven-plugin/3.2.0/bnd-maven-plugin-3.2.0.jar
[ERROR] urls[1] = file:/home/jenkins/.m2/repository/org/sonatype/plexus/plexus-build-api/0.0.7/plexus-build-api-0.0.7.jar
[ERROR] urls[2] = file:/home/jenkins/.m2/repository/org/codehaus/plexus/plexus-utils/1.5.8/plexus-utils-1.5.8.jar
[ERROR] urls[3] = file:/home/jenkins/.m2/repository/biz/aQute/bnd/biz.aQute.bndlib/3.2.0/biz.aQute.bndlib-3.2.0.jar
[ERROR] Number of foreign imports: 1
[ERROR] import: Entry[import  from realm ClassRealm[maven.api, parent: null]]
[ERROR] 
[ERROR] -----------------------------------------------------: org.slf4j.LoggerFactory
[ERROR] -> [Help 1]
[ERROR] 
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR] 
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/PluginContainerException
```