### PR TITLE
Use ConversionUtils to wrap objects and make the helper public

### DIFF
--- a/src/main/java/io/vertx/spi/cluster/hazelcast/impl/ConversionUtils.java
+++ b/src/main/java/io/vertx/spi/cluster/hazelcast/impl/ConversionUtils.java
@@ -1,15 +1,17 @@
 package io.vertx.spi.cluster.hazelcast.impl;
 
+import java.io.IOException;
+
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.DataSerializable;
+
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.shareddata.impl.ClusterSerializable;
 
-import java.io.IOException;
+public class ConversionUtils {
 
-class ConversionUtils {
-    static <T> T convertParam(T obj) {
+  public static <T> T convertParam(T obj) {
         if (obj instanceof ClusterSerializable) {
             ClusterSerializable cobj = (ClusterSerializable)obj;
             return (T)(new DataSerializableHolder(cobj));
@@ -19,7 +21,7 @@ class ConversionUtils {
     }
 
     @SuppressWarnings("unchecked")
-    static  <T> T convertReturn(Object obj) {
+   public static  <T> T convertReturn(Object obj) {
         if (obj instanceof DataSerializableHolder) {
             DataSerializableHolder cobj = (DataSerializableHolder)obj;
             return (T)cobj.clusterSerializable();

--- a/src/main/java/io/vertx/spi/cluster/hazelcast/impl/HazelcastAsyncMap.java
+++ b/src/main/java/io/vertx/spi/cluster/hazelcast/impl/HazelcastAsyncMap.java
@@ -16,19 +16,17 @@
 
 package io.vertx.spi.cluster.hazelcast.impl;
 
+import java.util.concurrent.TimeUnit;
+
 import com.hazelcast.core.IMap;
-import com.hazelcast.nio.ObjectDataInput;
-import com.hazelcast.nio.ObjectDataOutput;
-import com.hazelcast.nio.serialization.DataSerializable;
+
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
-import io.vertx.core.buffer.Buffer;
 import io.vertx.core.shareddata.AsyncMap;
-import io.vertx.core.shareddata.impl.ClusterSerializable;
 
-import java.io.IOException;
-import java.util.concurrent.TimeUnit;
+import static io.vertx.spi.cluster.hazelcast.impl.ConversionUtils.convertParam;
+import static io.vertx.spi.cluster.hazelcast.impl.ConversionUtils.convertReturn;
 
 public class HazelcastAsyncMap<K, V> implements AsyncMap<K, V> {
 
@@ -122,83 +120,5 @@ public class HazelcastAsyncMap<K, V> implements AsyncMap<K, V> {
   public void size(Handler<AsyncResult<Integer>> resultHandler) {
     vertx.executeBlocking(fut -> fut.complete(map.size()), resultHandler);
   }
-
-  @SuppressWarnings("unchecked")
-  private <T> T convertParam(T obj) {
-    if (obj instanceof ClusterSerializable) {
-      ClusterSerializable cobj = (ClusterSerializable)obj;
-      return (T)(new DataSerializableHolder(cobj));
-    } else {
-      return obj;
-    }
-  }
-
-  @SuppressWarnings("unchecked")
-  private <T> T convertReturn(Object obj) {
-    if (obj instanceof DataSerializableHolder) {
-      DataSerializableHolder cobj = (DataSerializableHolder)obj;
-      return (T)cobj.clusterSerializable();
-    } else {
-      return (T)obj;
-    }
-  }
-
-  private static final class DataSerializableHolder implements DataSerializable {
-
-    private ClusterSerializable clusterSerializable;
-
-    public DataSerializableHolder() {
-    }
-
-    private DataSerializableHolder(ClusterSerializable clusterSerializable) {
-      this.clusterSerializable = clusterSerializable;
-    }
-
-    @Override
-    public void writeData(ObjectDataOutput objectDataOutput) throws IOException {
-      objectDataOutput.writeUTF(clusterSerializable.getClass().getName());
-      Buffer buffer = Buffer.buffer();
-      clusterSerializable.writeToBuffer(buffer);
-      byte[] bytes = buffer.getBytes();
-      objectDataOutput.writeInt(bytes.length);
-      objectDataOutput.write(bytes);
-    }
-
-    @Override
-    public void readData(ObjectDataInput objectDataInput) throws IOException {
-      String className = objectDataInput.readUTF();
-      int length = objectDataInput.readInt();
-      byte[] bytes = new byte[length];
-      objectDataInput.readFully(bytes);
-      try {
-        Class<?> clazz = Thread.currentThread().getContextClassLoader().loadClass(className);
-        clusterSerializable = (ClusterSerializable)clazz.newInstance();
-        clusterSerializable.readFromBuffer(0, Buffer.buffer(bytes));
-      } catch (Exception e) {
-        throw new IllegalStateException("Failed to load class " + e.getMessage(), e);
-      }
-    }
-
-    @Override
-    public boolean equals(Object o) {
-      if (this == o) return true;
-      if (!(o instanceof DataSerializableHolder)) return false;
-      DataSerializableHolder that = (DataSerializableHolder) o;
-      if (clusterSerializable != null ? !clusterSerializable.equals(that.clusterSerializable) : that.clusterSerializable != null) {
-        return false;
-      }
-      return true;
-    }
-
-    @Override
-    public int hashCode() {
-      return clusterSerializable != null ? clusterSerializable.hashCode() : 0;
-    }
-
-    public ClusterSerializable clusterSerializable() {
-      return clusterSerializable;
-    }
-  }
-
 
 }

--- a/src/main/java/io/vertx/spi/cluster/hazelcast/impl/HazelcastInternalAsyncMap.java
+++ b/src/main/java/io/vertx/spi/cluster/hazelcast/impl/HazelcastInternalAsyncMap.java
@@ -16,15 +16,15 @@
 
 package io.vertx.spi.cluster.hazelcast.impl;
 
+import java.util.concurrent.TimeUnit;
+
 import com.hazelcast.core.ICompletableFuture;
 import com.hazelcast.core.IMap;
+
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
 import io.vertx.core.shareddata.AsyncMap;
-
-import java.util.concurrent.Callable;
-import java.util.concurrent.TimeUnit;
 
 import static io.vertx.spi.cluster.hazelcast.impl.ConversionUtils.convertParam;
 import static io.vertx.spi.cluster.hazelcast.impl.ConversionUtils.convertReturn;


### PR DESCRIPTION
Make HazelcastAsyncMap use the helper ConversionUtils to wrap objects pushed in its map. Make ConversionUtils public.

Signed-off-by: BELBEY <k.belbey.ext@viaccess-orca.com>