### PR TITLE
Updates to use latest stable Hazelcast version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
   <properties>
     <stack.version>3.4.2-SNAPSHOT</stack.version>
     <asciidoc.dir>${project.basedir}/src/main/asciidoc</asciidoc.dir>
-    <hazelcast.version>3.6.3</hazelcast.version>
+    <hazelcast.version>3.8.1</hazelcast.version>
   </properties>
 
   <dependencyManagement>

--- a/src/main/asciidoc/java/index.adoc
+++ b/src/main/asciidoc/java/index.adoc
@@ -283,7 +283,7 @@ See the http://docs.hazelcast.org/docs/3.6.1/manual/html-single/index.html#loggi
 
 == Using a different Hazelcast version
 
-You may want to use a different version of Hazelcast. The default version is `3.6.3`. To do so, you
+You may want to use a different version of Hazelcast. The default version is `3.8.1`. To do so, you
 need to:
 
 * put the version you want in the application classpath

--- a/src/main/java/io/vertx/spi/cluster/hazelcast/HazelcastClusterManager.java
+++ b/src/main/java/io/vertx/spi/cluster/hazelcast/HazelcastClusterManager.java
@@ -18,7 +18,6 @@ package io.vertx.spi.cluster.hazelcast;
 
 import com.hazelcast.config.Config;
 import com.hazelcast.config.XmlConfigBuilder;
-import com.hazelcast.core.AsyncAtomicLong;
 import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IAtomicLong;
@@ -253,7 +252,7 @@ public class HazelcastClusterManager implements ExtendedClusterManager, Membersh
     vertx.executeBlocking(fut ->
         fut.complete(
           USE_HZ_ASYNC_API ?
-            new HazelcastInternalAsyncCounter(vertx, (AsyncAtomicLong) hazelcast.getAtomicLong(name)) :
+            new HazelcastInternalAsyncCounter(vertx, hazelcast.getAtomicLong(name)) :
             new HazelcastCounter(hazelcast.getAtomicLong(name))
         )
       , resultHandler);

--- a/src/main/java/io/vertx/spi/cluster/hazelcast/impl/HazelcastInternalAsyncCounter.java
+++ b/src/main/java/io/vertx/spi/cluster/hazelcast/impl/HazelcastInternalAsyncCounter.java
@@ -14,7 +14,7 @@
  * You may elect to redistribute this code under either of these licenses.
  */package io.vertx.spi.cluster.hazelcast.impl;
 
-import com.hazelcast.core.AsyncAtomicLong;
+import com.hazelcast.core.IAtomicLong;
 import com.hazelcast.core.ICompletableFuture;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Handler;
@@ -22,7 +22,6 @@ import io.vertx.core.Vertx;
 import io.vertx.core.shareddata.Counter;
 
 import java.util.Objects;
-import java.util.concurrent.Callable;
 
 /**
  *
@@ -30,11 +29,11 @@ import java.util.concurrent.Callable;
 public class HazelcastInternalAsyncCounter
         implements Counter {
 
-    private final AsyncAtomicLong atomicLong;
+    private final IAtomicLong atomicLong;
     private final Vertx vertx;
 
 
-    public HazelcastInternalAsyncCounter(Vertx vertx, AsyncAtomicLong atomicLong) {
+    public HazelcastInternalAsyncCounter(Vertx vertx, IAtomicLong atomicLong) {
         this.vertx = vertx;
         this.atomicLong = atomicLong;
     }
@@ -42,43 +41,43 @@ public class HazelcastInternalAsyncCounter
     @Override
     public void get(Handler<AsyncResult<Long>> resultHandler) {
         Objects.requireNonNull(resultHandler, "resultHandler");
-        executeAsync(atomicLong.asyncGet(), resultHandler);
+        executeAsync(atomicLong.getAsync(), resultHandler);
     }
 
     @Override
     public void incrementAndGet(Handler<AsyncResult<Long>> resultHandler) {
         Objects.requireNonNull(resultHandler, "resultHandler");
-        executeAsync(atomicLong.asyncIncrementAndGet(), resultHandler);
+        executeAsync(atomicLong.incrementAndGetAsync(), resultHandler);
     }
 
     @Override
     public void getAndIncrement(Handler<AsyncResult<Long>> resultHandler) {
         Objects.requireNonNull(resultHandler, "resultHandler");
-        executeAsync(atomicLong.asyncGetAndIncrement(), resultHandler);
+        executeAsync(atomicLong.getAndIncrementAsync(), resultHandler);
     }
 
     @Override
     public void decrementAndGet(Handler<AsyncResult<Long>> resultHandler) {
         Objects.requireNonNull(resultHandler, "resultHandler");
-        executeAsync(atomicLong.asyncDecrementAndGet(), resultHandler);
+        executeAsync(atomicLong.decrementAndGetAsync(), resultHandler);
     }
 
     @Override
     public void addAndGet(long value, Handler<AsyncResult<Long>> resultHandler) {
         Objects.requireNonNull(resultHandler, "resultHandler");
-        executeAsync(atomicLong.asyncAddAndGet(value), resultHandler);
+        executeAsync(atomicLong.addAndGetAsync(value), resultHandler);
     }
 
     @Override
     public void getAndAdd(long value, Handler<AsyncResult<Long>> resultHandler) {
         Objects.requireNonNull(resultHandler, "resultHandler");
-        executeAsync(atomicLong.asyncGetAndAdd(value), resultHandler);
+        executeAsync(atomicLong.getAndAddAsync(value), resultHandler);
     }
 
     @Override
     public void compareAndSet(long expected, long value, Handler<AsyncResult<Boolean>> resultHandler) {
         Objects.requireNonNull(resultHandler, "resultHandler");
-        executeAsync(atomicLong.asyncCompareAndSet(expected, value),
+        executeAsync(atomicLong.compareAndSetAsync(expected, value),
                         resultHandler);
     }
 

--- a/src/main/java/io/vertx/spi/cluster/hazelcast/impl/HazelcastInternalAsyncMap.java
+++ b/src/main/java/io/vertx/spi/cluster/hazelcast/impl/HazelcastInternalAsyncMap.java
@@ -40,7 +40,7 @@ public class HazelcastInternalAsyncMap<K, V> implements AsyncMap<K, V> {
   @Override
   public void get(K k, Handler<AsyncResult<V>> asyncResultHandler) {
     executeAsync(
-            (ICompletableFuture<V>)map.getAsync(convertParam(k)),
+            map.getAsync(convertParam(k)),
             asyncResultHandler
     );
   }
@@ -50,7 +50,7 @@ public class HazelcastInternalAsyncMap<K, V> implements AsyncMap<K, V> {
     K kk = convertParam(k);
     V vv = convertParam(v);
     executeAsyncVoid(
-            (ICompletableFuture<Void>)map.putAsync(kk, vv),
+            map.setAsync(kk, vv),
             completionHandler
     );
   }

--- a/src/main/resources/default-cluster.xml
+++ b/src/main/resources/default-cluster.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<hazelcast xsi:schemaLocation="http://www.hazelcast.com/schema/config hazelcast-config-3.2.xsd"
+<hazelcast xsi:schemaLocation="http://www.hazelcast.com/schema/config hazelcast-config-3.8.xsd"
            xmlns="http://www.hazelcast.com/schema/config"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <properties>

--- a/src/test/resources/cluster.xml
+++ b/src/test/resources/cluster.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<hazelcast xsi:schemaLocation="http://www.hazelcast.com/schema/config hazelcast-config-3.2.xsd"
+<hazelcast xsi:schemaLocation="http://www.hazelcast.com/schema/config hazelcast-config-3.8.xsd"
            xmlns="http://www.hazelcast.com/schema/config"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <properties>


### PR DESCRIPTION
Uses `IAtomicLong` public API async methods in async counter implementation: since Hazelcast 3.7, async methods are exposed in IAtomicLong API, so there is no need to use internal class `AsyncAtomicLong`.

Also removes unnecessary cast to `ICompletableFuture` when using `IMap` async methods: since Hazelcast 3.7 these methods return an `ICompletableFuture` instead of plain `Future`.

Fixes #60 