### PR TITLE
Try not to block Hazelcast operation thread too long

### DIFF
--- a/src/main/java/io/vertx/spi/cluster/hazelcast/HazelcastClusterManager.java
+++ b/src/main/java/io/vertx/spi/cluster/hazelcast/HazelcastClusterManager.java
@@ -206,6 +206,7 @@ public class HazelcastClusterManager implements ClusterManager, MembershipListen
         long start = System.nanoTime();
         try {
           locked = iSemaphore.tryAcquire(remaining > 5000 ? 5000 : remaining, TimeUnit.MILLISECONDS);
+          Thread.sleep(1);
         } catch (InterruptedException e) {
           // OK continue
         }

--- a/src/main/java/io/vertx/spi/cluster/hazelcast/HazelcastClusterManager.java
+++ b/src/main/java/io/vertx/spi/cluster/hazelcast/HazelcastClusterManager.java
@@ -205,7 +205,7 @@ public class HazelcastClusterManager implements ClusterManager, MembershipListen
       do {
         long start = System.nanoTime();
         try {
-          locked = iSemaphore.tryAcquire(remaining, TimeUnit.MILLISECONDS);
+          locked = iSemaphore.tryAcquire(remaining > 5000 ? 5000 : remaining, TimeUnit.MILLISECONDS);
         } catch (InterruptedException e) {
           // OK continue
         }


### PR DESCRIPTION
Per Hazelcast's document, one or more partitions are dedicated to one
operation thread, any operation on the same partition that takes long time will block this
thread, and following operations will be blocked. Given that a lock is
acquired and not released for a long time, another acquire attempt
with long timeout on the same lock will block the HZ operation thread.

The change here is to use a smaller timeout value and more attempts to
acquire a permit in semaphore.

Signed-off-by: Richard MENG <mengangr@foxmail.com>