### PR TITLE
3.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,12 +9,12 @@
   </parent>
 
   <artifactId>vertx-hazelcast</artifactId>
-  <version>3.6.2-SNAPSHOT</version>
+  <version>3.6.2</version>
 
   <name>Vert.x Hazelcast Cluster Manager</name>
 
   <properties>
-    <stack.version>3.6.2-SNAPSHOT</stack.version>
+    <stack.version>3.6.2</stack.version>
     <asciidoc.dir>${project.basedir}/src/main/asciidoc</asciidoc.dir>
     <hazelcast.version>3.10.5</hazelcast.version>
     <hazelcast-kubernetes.version>1.2</hazelcast-kubernetes.version>

--- a/pom.xml
+++ b/pom.xml
@@ -9,12 +9,12 @@
   </parent>
 
   <artifactId>vertx-hazelcast</artifactId>
-  <version>3.6.3-SNAPSHOT</version>
+  <version>3.6.3</version>
 
   <name>Vert.x Hazelcast Cluster Manager</name>
 
   <properties>
-    <stack.version>3.6.3-SNAPSHOT</stack.version>
+    <stack.version>3.6.3</stack.version>
     <asciidoc.dir>${project.basedir}/src/main/asciidoc</asciidoc.dir>
     <hazelcast.version>3.10.5</hazelcast.version>
     <hazelcast-kubernetes.version>1.2</hazelcast-kubernetes.version>

--- a/pom.xml
+++ b/pom.xml
@@ -9,12 +9,12 @@
   </parent>
 
   <artifactId>vertx-hazelcast</artifactId>
-  <version>3.6.0</version>
+  <version>3.6.1-SNAPSHOT</version>
 
   <name>Vert.x Hazelcast Cluster Manager</name>
 
   <properties>
-    <stack.version>3.6.0</stack.version>
+    <stack.version>3.6.1-SNAPSHOT</stack.version>
     <asciidoc.dir>${project.basedir}/src/main/asciidoc</asciidoc.dir>
     <hazelcast.version>3.10.5</hazelcast.version>
     <hazelcast-kubernetes.version>1.2</hazelcast-kubernetes.version>

--- a/pom.xml
+++ b/pom.xml
@@ -9,12 +9,12 @@
   </parent>
 
   <artifactId>vertx-hazelcast</artifactId>
-  <version>3.6.3</version>
+  <version>3.6.4-SNAPSHOT</version>
 
   <name>Vert.x Hazelcast Cluster Manager</name>
 
   <properties>
-    <stack.version>3.6.3</stack.version>
+    <stack.version>3.6.4-SNAPSHOT</stack.version>
     <asciidoc.dir>${project.basedir}/src/main/asciidoc</asciidoc.dir>
     <hazelcast.version>3.10.5</hazelcast.version>
     <hazelcast-kubernetes.version>1.2</hazelcast-kubernetes.version>

--- a/pom.xml
+++ b/pom.xml
@@ -9,12 +9,12 @@
   </parent>
 
   <artifactId>vertx-hazelcast</artifactId>
-  <version>3.6.2</version>
+  <version>3.6.3-SNAPSHOT</version>
 
   <name>Vert.x Hazelcast Cluster Manager</name>
 
   <properties>
-    <stack.version>3.6.2</stack.version>
+    <stack.version>3.6.3-SNAPSHOT</stack.version>
     <asciidoc.dir>${project.basedir}/src/main/asciidoc</asciidoc.dir>
     <hazelcast.version>3.10.5</hazelcast.version>
     <hazelcast-kubernetes.version>1.2</hazelcast-kubernetes.version>

--- a/pom.xml
+++ b/pom.xml
@@ -9,12 +9,12 @@
   </parent>
 
   <artifactId>vertx-hazelcast</artifactId>
-  <version>3.6.1-SNAPSHOT</version>
+  <version>3.6.1</version>
 
   <name>Vert.x Hazelcast Cluster Manager</name>
 
   <properties>
-    <stack.version>3.6.1-SNAPSHOT</stack.version>
+    <stack.version>3.6.1</stack.version>
     <asciidoc.dir>${project.basedir}/src/main/asciidoc</asciidoc.dir>
     <hazelcast.version>3.10.5</hazelcast.version>
     <hazelcast-kubernetes.version>1.2</hazelcast-kubernetes.version>

--- a/pom.xml
+++ b/pom.xml
@@ -9,12 +9,12 @@
   </parent>
 
   <artifactId>vertx-hazelcast</artifactId>
-  <version>3.6.1</version>
+  <version>3.6.2-SNAPSHOT</version>
 
   <name>Vert.x Hazelcast Cluster Manager</name>
 
   <properties>
-    <stack.version>3.6.1</stack.version>
+    <stack.version>3.6.2-SNAPSHOT</stack.version>
     <asciidoc.dir>${project.basedir}/src/main/asciidoc</asciidoc.dir>
     <hazelcast.version>3.10.5</hazelcast.version>
     <hazelcast-kubernetes.version>1.2</hazelcast-kubernetes.version>


### PR DESCRIPTION
Hazelcast requires package=io.vertx.ext.healthchecks as mandatory resolution, Make it optional so that one can use it only if required