### PR TITLE
Perf improvements in subscription event handling

### DIFF
--- a/src/main/java/io/vertx/spi/cluster/hazelcast/impl/SubsMapHelper.java
+++ b/src/main/java/io/vertx/spi/cluster/hazelcast/impl/SubsMapHelper.java
@@ -31,7 +31,6 @@ import io.vertx.core.spi.cluster.RegistrationUpdateEvent;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
-import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
@@ -43,17 +42,16 @@ public class SubsMapHelper implements EntryListener<String, HazelcastRegistratio
 
   private static final Logger log = LoggerFactory.getLogger(SubsMapHelper.class);
 
-  private final VertxInternal vertx;
   private final Throttling throttling;
   private final MultiMap<String, HazelcastRegistrationInfo> map;
   private final NodeSelector nodeSelector;
   private final UUID listenerId;
 
   private final ConcurrentMap<String, Set<RegistrationInfo>> ownSubs = new ConcurrentHashMap<>();
+  private final ConcurrentMap<String, Set<RegistrationInfo>> localSubs = new ConcurrentHashMap<>();
   private final ReadWriteLock republishLock = new ReentrantReadWriteLock();
 
   public SubsMapHelper(VertxInternal vertx, HazelcastInstance hazelcast, NodeSelector nodeSelector) {
-    this.vertx = vertx;
     throttling = new Throttling(vertx, this::getAndUpdate);
     map = hazelcast.getMultiMap("__vertx.subs");
     this.nodeSelector = nodeSelector;
@@ -64,9 +62,28 @@ public class SubsMapHelper implements EntryListener<String, HazelcastRegistratio
     Lock readLock = republishLock.readLock();
     readLock.lock();
     try {
-      List<RegistrationInfo> list = new ArrayList<>();
-      for (HazelcastRegistrationInfo registrationInfo : map.get(address)) {
-        list.add(registrationInfo.unwrap());
+      List<RegistrationInfo> list;
+      int size;
+      Collection<HazelcastRegistrationInfo> remote = map.get(address);
+      size = remote.size();
+      Set<RegistrationInfo> local = localSubs.get(address);
+      if (local != null) {
+        synchronized (local) {
+          size += local.size();
+          if (size == 0) {
+            return Collections.emptyList();
+          }
+          list = new ArrayList<>(size);
+          list.addAll(local);
+        }
+      } else if (size == 0) {
+        return Collections.emptyList();
+      } else {
+        list = new ArrayList<>(size);
+      }
+      for (HazelcastRegistrationInfo hazelcastRegistrationInfo : remote) {
+        RegistrationInfo unwrap = hazelcastRegistrationInfo.unwrap();
+        list.add(unwrap);
       }
       return list;
     } finally {
@@ -78,29 +95,43 @@ public class SubsMapHelper implements EntryListener<String, HazelcastRegistratio
     Lock readLock = republishLock.readLock();
     readLock.lock();
     try {
-      ownSubs.compute(address, (add, curr) -> {
-        Set<RegistrationInfo> res = curr != null ? curr : new CopyOnWriteArraySet<>();
-        res.add(registrationInfo);
-        return res;
-      });
-      map.put(address, new HazelcastRegistrationInfo(registrationInfo));
+      if (registrationInfo.localOnly()) {
+        localSubs.compute(address, (add, curr) -> addToSet(registrationInfo, curr));
+        fireRegistrationUpdateEvent(address);
+      } else {
+        ownSubs.compute(address, (add, curr) -> addToSet(registrationInfo, curr));
+        map.put(address, new HazelcastRegistrationInfo(registrationInfo));
+      }
     } finally {
       readLock.unlock();
     }
+  }
+
+  private Set<RegistrationInfo> addToSet(RegistrationInfo registrationInfo, Set<RegistrationInfo> curr) {
+    Set<RegistrationInfo> res = curr != null ? curr : Collections.synchronizedSet(new LinkedHashSet<>());
+    res.add(registrationInfo);
+    return res;
   }
 
   public void remove(String address, RegistrationInfo registrationInfo) {
     Lock readLock = republishLock.readLock();
     readLock.lock();
     try {
-      ownSubs.computeIfPresent(address, (add, curr) -> {
-        curr.remove(registrationInfo);
-        return curr.isEmpty() ? null : curr;
-      });
-      map.remove(address, new HazelcastRegistrationInfo(registrationInfo));
+      if (registrationInfo.localOnly()) {
+        localSubs.computeIfPresent(address, (add, curr) -> removeFromSet(registrationInfo, curr));
+        fireRegistrationUpdateEvent(address);
+      } else {
+        ownSubs.computeIfPresent(address, (add, curr) -> removeFromSet(registrationInfo, curr));
+        map.remove(address, new HazelcastRegistrationInfo(registrationInfo));
+      }
     } finally {
       readLock.unlock();
     }
+  }
+
+  private Set<RegistrationInfo> removeFromSet(RegistrationInfo registrationInfo, Set<RegistrationInfo> curr) {
+    curr.remove(registrationInfo);
+    return curr.isEmpty() ? null : curr;
   }
 
   public void removeAllForNodes(Set<String> nodeIds) {
@@ -141,7 +172,7 @@ public class SubsMapHelper implements EntryListener<String, HazelcastRegistratio
     try {
       registrationInfos = get(address);
     } catch (Exception e) {
-      log.trace("A failure occured while retrieving the updated registrations", e);
+      log.trace("A failure occurred while retrieving the updated registrations", e);
       registrationInfos = Collections.emptyList();
     }
     nodeSelector.registrationsUpdated(new RegistrationUpdateEvent(address, registrationInfos));

--- a/src/main/java/io/vertx/spi/cluster/hazelcast/impl/Throttling.java
+++ b/src/main/java/io/vertx/spi/cluster/hazelcast/impl/Throttling.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2021 Red Hat, Inc.
+ *
+ * Red Hat licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.vertx.spi.cluster.hazelcast.impl;
+
+import io.vertx.core.impl.VertxInternal;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.function.Consumer;
+
+public class Throttling {
+
+  // @formatter:off
+  private enum State {
+    NEW {
+      State pending() { return PENDING; }
+      State start() { return RUNNING; }
+      State done() { throw new IllegalStateException(); }
+      State next() { throw new IllegalStateException(); }
+    },
+    PENDING {
+      State pending() { return this; }
+      State start() { return RUNNING; }
+      State done() { throw new IllegalStateException(); }
+      State next() { throw new IllegalStateException(); }
+    },
+    RUNNING {
+      State pending() { return RUNNING_PENDING; }
+      State start() { throw new IllegalStateException(); }
+      State done() { return FINISHED; }
+      State next() { throw new IllegalStateException(); }
+    },
+    RUNNING_PENDING {
+      State pending() { return this; }
+      State start() { throw new IllegalStateException(); }
+      State done() { return FINISHED_PENDING; }
+      State next() { throw new IllegalStateException(); }
+    },
+    FINISHED {
+      State pending() { return FINISHED_PENDING; }
+      State start() { throw new IllegalStateException(); }
+      State done() { throw new IllegalStateException(); }
+      State next() { return null; }
+    },
+    FINISHED_PENDING {
+      State pending() { return this; }
+      State start() { throw new IllegalStateException(); }
+      State done() { throw new IllegalStateException(); }
+      State next() { return NEW; }
+    };
+
+    abstract State pending();
+    abstract State start();
+    abstract State done();
+    abstract State next();
+  }
+  // @formatter:on
+
+  private final VertxInternal vertx;
+  private final Consumer<String> action;
+  private final ConcurrentMap<String, State> map;
+
+  public Throttling(VertxInternal vertx, Consumer<String> action) {
+    this.vertx = vertx;
+    this.action = action;
+    map = new ConcurrentHashMap<>();
+  }
+
+  public void onEvent(String address) {
+    State curr = map.compute(address, (s, state) -> state == null ? State.NEW : state.pending());
+    if (curr == State.NEW) {
+      vertx.executeBlocking(promise -> {
+        run(address);
+        promise.complete();
+      }, false);
+    }
+  }
+
+  private void run(String address) {
+    map.computeIfPresent(address, (s, state) -> state.start());
+    try {
+      action.accept(address);
+    } finally {
+      map.computeIfPresent(address, (s, state) -> state.done());
+      vertx.setTimer(20, l-> {
+        vertx.executeBlocking(promise-> {
+          checkState(address);
+          promise.complete();
+        }, false);
+      });
+    }
+  }
+
+  private void checkState(String address) {
+    State curr = map.computeIfPresent(address, (s, state) -> state.next());
+    if (curr == State.NEW) {
+      run(address);
+    }
+  }
+}

--- a/src/test/java/io/vertx/spi/cluster/hazelcast/impl/ThrottlingTest.java
+++ b/src/test/java/io/vertx/spi/cluster/hazelcast/impl/ThrottlingTest.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2021 Red Hat, Inc.
+ *
+ * Red Hat licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.vertx.spi.cluster.hazelcast.impl;
+
+import io.vertx.core.impl.VertxInternal;
+import io.vertx.test.core.VertxTestBase;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.concurrent.*;
+
+import static java.util.concurrent.TimeUnit.*;
+
+public class ThrottlingTest extends VertxTestBase {
+
+  int threadCount = 4;
+  ExecutorService executorService;
+
+  @Override
+  public void setUp() throws Exception {
+    super.setUp();
+    executorService = Executors.newFixedThreadPool(threadCount);
+  }
+
+  @Test
+  public void testInterval() throws Exception {
+    int duration = 5;
+    String[] addresses = {"foo", "bar", "baz", "qux"};
+
+    ConcurrentMap<String, List<Long>> events = new ConcurrentHashMap<>(addresses.length);
+    Throttling throttling = new Throttling((VertxInternal) vertx, address -> {
+      events.compute(address, (k, v) -> {
+        if (v == null) {
+          v = Collections.synchronizedList(new LinkedList<>());
+        }
+        v.add(System.nanoTime());
+        return v;
+      });
+      sleep(1);
+    });
+
+    CountDownLatch latch = new CountDownLatch(threadCount);
+    long start = System.nanoTime();
+    for (int i = 0; i < threadCount; i++) {
+      executorService.submit(() -> {
+        try {
+          do {
+            sleepMax(5);
+            throttling.onEvent(addresses[ThreadLocalRandom.current().nextInt(addresses.length)]);
+          } while (SECONDS.convert(System.nanoTime() - start, NANOSECONDS) < duration);
+        } finally {
+          latch.countDown();
+        }
+      });
+    }
+    latch.await();
+
+    assertWaitUntil(() -> {
+      if (events.size() != addresses.length) {
+        return false;
+      }
+      for (List<Long> nanoTimes : events.values()) {
+        Long previous = null;
+        for (Long nanoTime : nanoTimes) {
+          if (previous != null) {
+            if (MILLISECONDS.convert(nanoTime - previous, NANOSECONDS) < 20) {
+              return false;
+            }
+          }
+          previous = nanoTime;
+        }
+      }
+      return true;
+    }, 1000);
+  }
+
+  private void sleepMax(long time) {
+    sleep(ThreadLocalRandom.current().nextLong(time));
+  }
+
+  private void sleep(long time) {
+    try {
+      MILLISECONDS.sleep(time);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+    }
+  }
+
+  @Override
+  protected void tearDown() throws Exception {
+    executorService.shutdown();
+    assertTrue(executorService.awaitTermination(5, SECONDS));
+    super.tearDown();
+  }
+}


### PR DESCRIPTION
Follows-up on eclipse-vertx/vert.x#3843

The improvements mostly consist in:

- keeping local consumers data on the node

This reduces the traffic and prevents for notifying other nodes (which are not interested anyway).

- throttling subs lookups

This reduces traffic and load on all nodes


Related to eclipse-vertx/vert.x#3797