### PR TITLE
Make sure NodeSelector wants update before sending a backend query

### DIFF
--- a/src/main/java/io/vertx/spi/cluster/hazelcast/impl/SubsMapHelper.java
+++ b/src/main/java/io/vertx/spi/cluster/hazelcast/impl/SubsMapHelper.java
@@ -168,14 +168,16 @@ public class SubsMapHelper implements EntryListener<String, HazelcastRegistratio
   }
 
   private void getAndUpdate(String address) {
-    List<RegistrationInfo> registrationInfos;
-    try {
-      registrationInfos = get(address);
-    } catch (Exception e) {
-      log.trace("A failure occurred while retrieving the updated registrations", e);
-      registrationInfos = Collections.emptyList();
+    if (nodeSelector.wantsUpdatesFor(address)) {
+      List<RegistrationInfo> registrationInfos;
+      try {
+        registrationInfos = get(address);
+      } catch (Exception e) {
+        log.trace("A failure occurred while retrieving the updated registrations", e);
+        registrationInfos = Collections.emptyList();
+      }
+      nodeSelector.registrationsUpdated(new RegistrationUpdateEvent(address, registrationInfos));
     }
-    nodeSelector.registrationsUpdated(new RegistrationUpdateEvent(address, registrationInfos));
   }
 
   @Override


### PR DESCRIPTION
This can help reduce load/traffic when a node is not sending messages to an address that gets subscription updates.