### PR TITLE
Bump Hazelcast from 4.0.2 to 4.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
   <properties>
     <stack.version>4.1.1-SNAPSHOT</stack.version>
     <asciidoc.dir>${project.basedir}/src/main/asciidoc</asciidoc.dir>
-    <hazelcast.version>4.0.2</hazelcast.version>
+    <hazelcast.version>4.1</hazelcast.version>
     <hazelcast-kubernetes.version>2.0.1</hazelcast-kubernetes.version>
     <jar.manifest>${project.basedir}/src/main/resources/META-INF/MANIFEST.MF</jar.manifest>
   </properties>


### PR DESCRIPTION
#### Motivation:

Hazelcast 4.1 includes a security fix (https://github.com/hazelcast/hazelcast/pull/17722). This fix was packported to `4.0.x`, but the fix version (4.0.4) has yet to be released.

It may be prudent to upgrade to `4.1.1` or `4.1.2`, as those include additional fixes. However, 4.0.2 -> 4.1 includes some breaking changes as well.
https://docs.hazelcast.org/docs/rn/index.html#4-1 