### PR TITLE
Fixes #152 - Fallback to another classLoader when first one failed

### DIFF
--- a/src/main/java/io/vertx/spi/cluster/hazelcast/impl/ConversionUtils.java
+++ b/src/main/java/io/vertx/spi/cluster/hazelcast/impl/ConversionUtils.java
@@ -68,15 +68,14 @@ public class ConversionUtils {
     }
 
     private Class<?> loadClass(String className) throws ClassNotFoundException {
-      Class<?> res = null;
       ClassLoader tccl = Thread.currentThread().getContextClassLoader();
-      if (tccl != null) {
-        res = tccl.loadClass(className);
+      try {
+        if (tccl != null) {
+          return tccl.loadClass(className);
+        }
+      } catch(ClassNotFoundException ignored) {
       }
-      if (res == null) {
-        return ConversionUtils.class.getClassLoader().loadClass(className);
-      }
-      return res;
+      return ConversionUtils.class.getClassLoader().loadClass(className);
     }
 
     @Override


### PR DESCRIPTION
This fixes #152 

When loading a class and the classloader fails, we do not try with another one. 
Moreover, the second classloader can never be called

