### PR TITLE
Use dedicated executor to execute throttling tasks

### DIFF
--- a/src/main/java/io/vertx/spi/cluster/hazelcast/HazelcastClusterManager.java
+++ b/src/main/java/io/vertx/spi/cluster/hazelcast/HazelcastClusterManager.java
@@ -136,7 +136,7 @@ public class HazelcastClusterManager implements ClusterManager, MembershipListen
         membershipListenerId = hazelcast.getCluster().addMembershipListener(this);
         lifecycleListenerId = hazelcast.getLifecycleService().addLifecycleListener(this);
 
-        subsMapHelper = new SubsMapHelper(vertx, hazelcast, nodeSelector);
+        subsMapHelper = new SubsMapHelper(hazelcast, nodeSelector);
         nodeInfoMap = hazelcast.getMap("__vertx.nodeInfo");
 
         prom.complete();

--- a/src/main/java/io/vertx/spi/cluster/hazelcast/impl/SubsMapHelper.java
+++ b/src/main/java/io/vertx/spi/cluster/hazelcast/impl/SubsMapHelper.java
@@ -21,7 +21,6 @@ import com.hazelcast.core.EntryListener;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.map.MapEvent;
 import com.hazelcast.multimap.MultiMap;
-import io.vertx.core.impl.VertxInternal;
 import io.vertx.core.impl.logging.Logger;
 import io.vertx.core.impl.logging.LoggerFactory;
 import io.vertx.core.spi.cluster.NodeSelector;
@@ -51,8 +50,8 @@ public class SubsMapHelper implements EntryListener<String, HazelcastRegistratio
   private final ConcurrentMap<String, Set<RegistrationInfo>> localSubs = new ConcurrentHashMap<>();
   private final ReadWriteLock republishLock = new ReentrantReadWriteLock();
 
-  public SubsMapHelper(VertxInternal vertx, HazelcastInstance hazelcast, NodeSelector nodeSelector) {
-    throttling = new Throttling(vertx, this::getAndUpdate);
+  public SubsMapHelper(HazelcastInstance hazelcast, NodeSelector nodeSelector) {
+    throttling = new Throttling(this::getAndUpdate);
     map = hazelcast.getMultiMap("__vertx.subs");
     this.nodeSelector = nodeSelector;
     listenerId = map.addEntryListener(this, false);


### PR DESCRIPTION
Fixes #156

Otherwise, when Vert.x is closing, the Vert.x worker executor might be closed before the pending tasks have all been executed.