### PR TITLE
Upgrade hazelcast from 4.2.2 to 4.2.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
   <properties>
     <stack.version>4.3.5-SNAPSHOT</stack.version>
     <asciidoc.dir>${project.basedir}/src/main/asciidoc</asciidoc.dir>
-    <hazelcast.version>4.2.2</hazelcast.version>
+    <hazelcast.version>4.2.5</hazelcast.version>
     <hazelcast-kubernetes.version>2.2.3</hazelcast-kubernetes.version>
     <jar.manifest>${project.basedir}/src/main/resources/META-INF/MANIFEST.MF</jar.manifest>
   </properties>


### PR DESCRIPTION
Enhancements and fixes:
https://github.com/hazelcast/hazelcast/releases/tag/v4.2.5
https://github.com/hazelcast/hazelcast/releases/tag/v4.2.4
https://github.com/hazelcast/hazelcast/releases/tag/v4.2.3