### PR TITLE
Fix NPE in membership listener code

### DIFF
--- a/src/main/java/io/vertx/spi/cluster/hazelcast/HazelcastClusterManager.java
+++ b/src/main/java/io/vertx/spi/cluster/hazelcast/HazelcastClusterManager.java
@@ -131,12 +131,13 @@ public class HazelcastClusterManager implements ClusterManager, MembershipListen
           hazelcast = Hazelcast.newHazelcastInstance(conf);
         }
 
+        subsMapHelper = new SubsMapHelper(hazelcast, nodeSelector);
+
         Member localMember = hazelcast.getCluster().getLocalMember();
         nodeId = localMember.getUuid();
         membershipListenerId = hazelcast.getCluster().addMembershipListener(this);
         lifecycleListenerId = hazelcast.getLifecycleService().addLifecycleListener(this);
 
-        subsMapHelper = new SubsMapHelper(hazelcast, nodeSelector);
         nodeInfoMap = hazelcast.getMap("__vertx.nodeInfo");
 
         prom.complete();


### PR DESCRIPTION
See #162

subsMapHelper must be created before the membership listener is registered.

Otherwise, there is a tiny window of time when a notification can be handled and the helper field is null.