### PR TITLE
Upgrade to Hazelcast 4.2.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
   <properties>
     <stack.version>4.4.0-SNAPSHOT</stack.version>
     <asciidoc.dir>${project.basedir}/src/main/asciidoc</asciidoc.dir>
-    <hazelcast.version>4.2.6</hazelcast.version>
+    <hazelcast.version>4.2.7</hazelcast.version>
     <hazelcast-kubernetes.version>2.2.3</hazelcast-kubernetes.version>
     <jar.manifest>${project.basedir}/src/main/resources/META-INF/MANIFEST.MF</jar.manifest>
   </properties>


### PR DESCRIPTION
To be backported to 4.3 after merging.