### PR TITLE
Use fixed nodeId from HZ attributes config

### DIFF
--- a/src/main/asciidoc/index.adoc
+++ b/src/main/asciidoc/index.adoc
@@ -145,6 +145,10 @@ Notice that the custom Hazelcast instance need to be configured with:
 
 [source,xml]
 ----
+<member-attributes>
+  <attribute name="__vertx.nodeId">unique-identifier</attribute>
+</member-attributes>
+
 <multimap name="__vertx.subs">
   <backup-count>1</backup-count>
   <value-collection-type>SET</value-collection-type>
@@ -170,6 +174,9 @@ Notice that the custom Hazelcast instance need to be configured with:
 </cp-subsystem>
 ----
 
+CAUTION: The `__vertx.nodeId` is used by Vert.x as identifier of the node in the cluster.
+Make sure to configure unique values across members.
+
 IMPORTANT: Hazelcast clients or smart clients are not supported.
 
 IMPORTANT: Make sure Hazelcast is started before and shut down after Vert.x.
@@ -177,8 +184,8 @@ Also, the Hazelcast shutdown hook should be disabled (see xml example, or via sy
 
 == Changing timeout for failed nodes
 
-By default a node will be removed from the cluster if Hazelcast didn't receive a heartbeat for 300 seconds. To change
-this value `hazelcast.max.no.heartbeat.seconds` system property such as in:
+By default, a node will be removed from the cluster if Hazelcast didn't receive a heartbeat for 300 seconds.
+To change this value `hazelcast.max.no.heartbeat.seconds` system property such as in:
 
 ----
 -Dhazelcast.max.no.heartbeat.seconds=5

--- a/src/main/java/io/vertx/spi/cluster/hazelcast/HazelcastClusterManager.java
+++ b/src/main/java/io/vertx/spi/cluster/hazelcast/HazelcastClusterManager.java
@@ -173,7 +173,10 @@ public class HazelcastClusterManager implements ClusterManager, MembershipListen
   public List<String> getNodes() {
     List<String> list = new ArrayList<>();
     for (Member member : hazelcast.getCluster().getMembers()) {
-      list.add(member.getAttribute(NODE_ID_ATTRIBUTE));
+      String nodeId = member.getAttribute(NODE_ID_ATTRIBUTE);
+      if (nodeId != null) { // don't add data-only members
+        list.add(nodeId);
+      }
     }
     return list;
   }

--- a/src/main/java/io/vertx/spi/cluster/hazelcast/HazelcastClusterManager.java
+++ b/src/main/java/io/vertx/spi/cluster/hazelcast/HazelcastClusterManager.java
@@ -35,17 +35,32 @@ import io.vertx.core.impl.logging.LoggerFactory;
 import io.vertx.core.shareddata.AsyncMap;
 import io.vertx.core.shareddata.Counter;
 import io.vertx.core.shareddata.Lock;
-import io.vertx.core.spi.cluster.*;
-import io.vertx.spi.cluster.hazelcast.impl.*;
+import io.vertx.core.spi.cluster.ClusterManager;
+import io.vertx.core.spi.cluster.NodeInfo;
+import io.vertx.core.spi.cluster.NodeListener;
+import io.vertx.core.spi.cluster.NodeSelector;
+import io.vertx.core.spi.cluster.RegistrationInfo;
+import io.vertx.spi.cluster.hazelcast.impl.HazelcastAsyncMap;
+import io.vertx.spi.cluster.hazelcast.impl.HazelcastCounter;
+import io.vertx.spi.cluster.hazelcast.impl.HazelcastLock;
+import io.vertx.spi.cluster.hazelcast.impl.HazelcastNodeInfo;
+import io.vertx.spi.cluster.hazelcast.impl.SubsMapHelper;
+import io.vertx.spi.cluster.hazelcast.impl.SubsOpSerializer;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.UUID;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
 
-import static java.util.concurrent.TimeUnit.MILLISECONDS;
-import static java.util.concurrent.TimeUnit.NANOSECONDS;
+import static java.util.concurrent.TimeUnit.*;
 
 /**
  * A cluster manager that uses Hazelcast
@@ -57,12 +72,13 @@ public class HazelcastClusterManager implements ClusterManager, MembershipListen
   private static final Logger log = LoggerFactory.getLogger(HazelcastClusterManager.class);
 
   private static final String LOCK_SEMAPHORE_PREFIX = "__vertx.";
+  private static final String NODE_ID_ATTRIBUTE = "__vertx.nodeId";
 
   private VertxInternal vertx;
   private NodeSelector nodeSelector;
 
   private HazelcastInstance hazelcast;
-  private UUID nodeId;
+  private String nodeId;
   private NodeInfo nodeInfo;
   private SubsMapHelper subsMapHelper;
   private IMap<String, HazelcastNodeInfo> nodeInfoMap;
@@ -128,13 +144,16 @@ public class HazelcastClusterManager implements ClusterManager, MembershipListen
           // We have our own shutdown hook and need to ensure ours runs before Hazelcast is shutdown
           conf.setProperty("hazelcast.shutdownhook.enabled", "false");
 
+          nodeId = UUID.randomUUID().toString();
+          conf.getMemberAttributeConfig().setAttribute(NODE_ID_ATTRIBUTE, nodeId);
+
           hazelcast = Hazelcast.newHazelcastInstance(conf);
+        } else {
+          nodeId = hazelcast.getCluster().getLocalMember().getAttribute(NODE_ID_ATTRIBUTE);
         }
 
         subsMapHelper = new SubsMapHelper(hazelcast, nodeSelector);
 
-        Member localMember = hazelcast.getCluster().getLocalMember();
-        nodeId = localMember.getUuid();
         membershipListenerId = hazelcast.getCluster().addMembershipListener(this);
         lifecycleListenerId = hazelcast.getLifecycleService().addLifecycleListener(this);
 
@@ -147,14 +166,14 @@ public class HazelcastClusterManager implements ClusterManager, MembershipListen
 
   @Override
   public String getNodeId() {
-    return nodeId.toString();
+    return nodeId;
   }
 
   @Override
   public List<String> getNodes() {
     List<String> list = new ArrayList<>();
     for (Member member : hazelcast.getCluster().getMembers()) {
-      list.add(member.getUuid().toString());
+      list.add(member.getAttribute(NODE_ID_ATTRIBUTE));
     }
     return list;
   }
@@ -171,7 +190,7 @@ public class HazelcastClusterManager implements ClusterManager, MembershipListen
     }
     HazelcastNodeInfo value = new HazelcastNodeInfo(nodeInfo);
     vertx.executeBlocking(prom -> {
-      nodeInfoMap.put(nodeId.toString(), value);
+      nodeInfoMap.put(nodeId, value);
       prom.complete();
     }, false, promise);
   }
@@ -279,7 +298,7 @@ public class HazelcastClusterManager implements ClusterManager, MembershipListen
       return;
     }
     Member member = membershipEvent.getMember();
-    String nid = member.getUuid().toString();
+    String nid = member.getAttribute(NODE_ID_ATTRIBUTE);
     try {
       if (nodeListener != null) {
         nodeIds.add(nid);
@@ -296,7 +315,7 @@ public class HazelcastClusterManager implements ClusterManager, MembershipListen
       return;
     }
     Member member = membershipEvent.getMember();
-    String nid = member.getUuid().toString();
+    String nid = member.getAttribute(NODE_ID_ATTRIBUTE);
     try {
       membersRemoved(Collections.singleton(nid));
     } catch (Throwable t) {
@@ -307,7 +326,7 @@ public class HazelcastClusterManager implements ClusterManager, MembershipListen
   private synchronized void membersRemoved(Set<String> ids) {
     cleanSubs(ids);
     cleanNodeInfos(ids);
-    nodeInfoMap.put(nodeId.toString(), new HazelcastNodeInfo(getNodeInfo()));
+    nodeInfoMap.put(nodeId, new HazelcastNodeInfo(getNodeInfo()));
     nodeSelector.registrationsLost();
     republishOwnSubs();
     if (nodeListener != null) {

--- a/src/test/java/io/vertx/core/ProgrammaticHazelcastClusterManagerTest.java
+++ b/src/test/java/io/vertx/core/ProgrammaticHazelcastClusterManagerTest.java
@@ -29,6 +29,7 @@ import org.junit.Test;
 import java.math.BigInteger;
 import java.util.Map;
 import java.util.Random;
+import java.util.UUID;
 import java.util.concurrent.atomic.AtomicReference;
 
 /**
@@ -74,10 +75,12 @@ public class ProgrammaticHazelcastClusterManagerTest extends AsyncTestBase {
   }
 
   private Config createConfig() {
-    return new Config()
+    Config config = new Config()
       .setProperty("hazelcast.wait.seconds.before.join", "0")
       .setProperty("hazelcast.local.localAddress", "127.0.0.1")
       .setClusterName(System.getProperty("vertx.hazelcast.test.group.name"));
+    config.getMemberAttributeConfig().setAttribute("__vertx.nodeId", UUID.randomUUID().toString());
+    return config;
   }
 
   private void testProgrammatic(HazelcastClusterManager mgr, Config config) throws Exception {
@@ -205,7 +208,7 @@ public class ProgrammaticHazelcastClusterManagerTest extends AsyncTestBase {
   public void testThatExternalHZInstanceCanBeShutdown() {
     // This instance won't be used by vert.x
     HazelcastInstance instance = Hazelcast.newHazelcastInstance(createConfig());
-    String nodeID = instance.getCluster().getLocalMember().getUuid().toString();
+    String nodeID = instance.getCluster().getLocalMember().getAttribute("__vertx.nodeId");
 
     HazelcastClusterManager mgr = new HazelcastClusterManager(createConfig());
     VertxOptions options = new VertxOptions().setClusterManager(mgr);


### PR DESCRIPTION
Fixes #164

Hazelcast may change the member uuid if it goes out of the grid for a moment (e.g. if suspected to be unhealthy). We can't use this identifier as Vert.x nodeId.

Instead, we create one and store it as a member attribute. This has to happen before starting the member because in recent versions of Hazelcast, member attributes can no longer be updated.

As a consequence, users who rely on an existing Hazelcast instance will have to configure the attribute manually (breaking change, documented).