### PR TITLE
Try the best effort to support cluster containing member using a Vert…

### DIFF
--- a/src/main/java/io/vertx/spi/cluster/hazelcast/HazelcastClusterManager.java
+++ b/src/main/java/io/vertx/spi/cluster/hazelcast/HazelcastClusterManager.java
@@ -301,7 +301,7 @@ public class HazelcastClusterManager implements ClusterManager, MembershipListen
       return;
     }
     Member member = membershipEvent.getMember();
-    String nid = member.getAttribute(NODE_ID_ATTRIBUTE);
+    String nid = getNodeId(member);
     try {
       if (nodeListener != null) {
         nodeIds.add(nid);
@@ -318,12 +318,20 @@ public class HazelcastClusterManager implements ClusterManager, MembershipListen
       return;
     }
     Member member = membershipEvent.getMember();
-    String nid = member.getAttribute(NODE_ID_ATTRIBUTE);
+    String nid = getNodeId(member);
     try {
       membersRemoved(Collections.singleton(nid));
     } catch (Throwable t) {
       log.error("Failed to handle memberRemoved", t);
     }
+  }
+
+  private static String getNodeId(Member member) {
+    String nodeId = member.getAttribute(NODE_ID_ATTRIBUTE);
+    if (nodeId == null) {
+      nodeId = member.getUuid().toString();
+    }
+    return nodeId;
   }
 
   private synchronized void membersRemoved(Set<String> ids) {


### PR DESCRIPTION
…x version older than 4.4 (#174)

Motivation:

Fix for #174 
Trying the best effort to retrieve the member id by looking at the member UUID if the `__vertx.nodeId` is not present on the member.

Note:
It remains 3 usage to the `__vertx.nodeId` attribute:
- for 2 of them that are located in the method `io.vertx.spi.cluster.hazelcast.HazelcastClusterManager#join`, it does not seem to make sense to change it.
- for the last one that is located in method `io.vertx.spi.cluster.hazelcast.HazelcastClusterManager#getNodes` I'm not sure so I did not change it
 
 
