### PR TITLE
Upgrade hazelcast from 4.2.7 to 5.2.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,8 +16,7 @@
   <properties>
     <stack.version>5.0.0-SNAPSHOT</stack.version>
     <asciidoc.dir>${project.basedir}/src/main/asciidoc</asciidoc.dir>
-    <hazelcast.version>4.2.7</hazelcast.version>
-    <hazelcast-kubernetes.version>2.2.3</hazelcast-kubernetes.version>
+    <hazelcast.version>5.2.3</hazelcast.version>
     <jar.manifest>${project.basedir}/src/main/resources/META-INF/MANIFEST.MF</jar.manifest>
   </properties>
 


### PR DESCRIPTION
For IMDSv2 support hazelcast >= [5.2.2](https://github.com/hazelcast/hazelcast/releases/tag/v5.2.2) is needed.