### PR TITLE
Scheduled GH job for 4.x shall test both HZv4 and HZv5

### DIFF
--- a/.github/workflows/ci-4.x.yml
+++ b/.github/workflows/ci-4.x.yml
@@ -6,26 +6,34 @@ jobs:
   CI:
     strategy:
       matrix:
-        include:
-          - os: ubuntu-latest
-            jdk: 8
+        os: [ubuntu-latest]
+        jdk: [8,11]
+        hz: [4.2.8,5.3.2]
+        exclude:
+          - jdk: 8
+            hz: 5.3.2
     uses: ./.github/workflows/ci.yml
     with:
       branch: 4.x
       jdk: ${{ matrix.jdk }}
       os: ${{ matrix.os }}
+      hz: ${{ matrix.hz }}
     secrets: inherit
   IT:
     strategy:
       matrix:
-        include:
-          - os: ubuntu-latest
-            jdk: 8
+        os: [ubuntu-latest]
+        jdk: [8,11]
+        hz: [4.2.8,5.3.2]
+        exclude:
+          - jdk: 8
+            hz: 5.3.2
     uses: ./.github/workflows/it.yml
     with:
       branch: 4.x
       jdk: ${{ matrix.jdk }}
       os: ${{ matrix.os }}
+      hz: ${{ matrix.hz }}
     secrets: inherit
   Deploy:
     if: ${{ github.repository_owner == 'vert-x3' && (github.event_name == 'push' || github.event_name == 'schedule') }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,9 @@ on:
       os:
         default: ubuntu-latest
         type: string
+      hz:
+        default: 5.3.2
+        type: string
 jobs:
   Test:
     name: Run tests
@@ -26,4 +29,4 @@ jobs:
           java-version: ${{ inputs.jdk }}
           distribution: temurin
       - name: Run tests
-        run: mvn -s .github/maven-ci-settings.xml -B -DtestLogLevel=OFF test
+        run: mvn -s .github/maven-ci-settings.xml -Dhazelcast.version=${{ inputs.hz }} -B -DtestLogLevel=OFF test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ on:
         default: ubuntu-latest
         type: string
       hz:
-        default: 5.3.2
+        default: 4.2.8
         type: string
 jobs:
   Test:

--- a/.github/workflows/it.yml
+++ b/.github/workflows/it.yml
@@ -12,7 +12,7 @@ on:
         default: ubuntu-latest
         type: string
       hz:
-        default: 5.3.2
+        default: 4.2.8
         type: string
 jobs:
   Tests:

--- a/.github/workflows/it.yml
+++ b/.github/workflows/it.yml
@@ -11,6 +11,9 @@ on:
       os:
         default: ubuntu-latest
         type: string
+      hz:
+        default: 5.3.2
+        type: string
 jobs:
   Tests:
     name: Run integration tests
@@ -26,4 +29,4 @@ jobs:
           java-version: ${{ inputs.jdk }}
           distribution: temurin
       - name: Run integration tests
-        run: mvn -s .github/maven-ci-settings.xml -B -DtestLogLevel=OFF -Dtest=DoesNotExists verify
+        run: mvn -s .github/maven-ci-settings.xml -Dhazelcast.version=${{ inputs.hz }} -B -DtestLogLevel=OFF -Dtest=DoesNotExists verify


### PR DESCRIPTION
The scheduled build of Vert.x 4 is defined in the main branch.

Following-up on #184, we must configure this job to run the same tests as for pull requests and commits to the `4.x` branch.