### PR TITLE
Upgrade to Hazelcast 5.3.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
   <properties>
     <stack.version>4.5.8-SNAPSHOT</stack.version>
     <asciidoc.dir>${project.basedir}/src/main/asciidoc</asciidoc.dir>
-    <hazelcast.version>4.2.8</hazelcast.version>
+    <hazelcast.version>5.3.5</hazelcast.version>
     <hazelcast-kubernetes.version>2.2.3</hazelcast-kubernetes.version>
     <jar.manifest>${project.basedir}/src/main/resources/META-INF/MANIFEST.MF</jar.manifest>
   </properties>

--- a/src/main/asciidoc/index.adoc
+++ b/src/main/asciidoc/index.adoc
@@ -45,6 +45,12 @@ when you are creating your Vert.x instance, for example:
 {@link examples.Examples#example1()}
 ----
 
+== Hazelcast version
+
+Since Vert.x 4.5.8, the version of the Hazelcast dependency is changed to 5.3 since Hazelcast 4 is not anymore supported and 4.2.8 has known vulnerabilities (CVE-2023-45860, CVE-2023-45859, CVE-2023-33265, CVE-2023-33264).
+
+This cluster manager remains tested with Hazelcast 4.2.8 and 5.3, so 4.2.8 remains supported, the Hazelcast version must be explicitly set to 4.2.8 if needed until an upgrade can be achieved.
+
 [[configcluster]]
 == Configuring this cluster manager
 


### PR DESCRIPTION
Vert.x Hazelcast works with bot HZ 4.x and 5.x but still references 4.2.8 by default while it is tested in CI with 4.2.8 and 5.3.5.
    
Since HZ 4.x is not supported anymore in community and the 4.2.8 has CVE it is reasonnable to depend on 5.3.5 in our pom while testing with 4.3.8 and 5.3.5.
