### PR TITLE
Implement Lock and Counter without using CP subsystem

### DIFF
--- a/src/main/asciidoc/index.adoc
+++ b/src/main/asciidoc/index.adoc
@@ -161,17 +161,6 @@ Notice that the custom Hazelcast instance need to be configured with:
 <map name="__vertx.nodeInfo">
   <backup-count>1</backup-count>
 </map>
-
-<cp-subsystem>
-  <cp-member-count>0</cp-member-count>
-  <semaphores>
-    <semaphore>
-      <name>__vertx.*</name>
-      <jdk-compatible>false</jdk-compatible>
-      <initial-permits>1</initial-permits>
-    </semaphore>
-  </semaphores>
-</cp-subsystem>
 ----
 
 CAUTION: The `__vertx.nodeId` is used by Vert.x as identifier of the node in the cluster.
@@ -184,7 +173,7 @@ Also, the Hazelcast shutdown hook should be disabled (see xml example, or via sy
 
 == Changing timeout for failed nodes
 
-By default, a node will be removed from the cluster if Hazelcast didn't receive a heartbeat for 300 seconds.
+By default, a node will be removed from the cluster if Hazelcast didn't receive a heartbeat for 60 seconds.
 To change this value `hazelcast.max.no.heartbeat.seconds` system property such as in:
 
 ----

--- a/src/main/java/io/vertx/spi/cluster/hazelcast/HazelcastClusterManager.java
+++ b/src/main/java/io/vertx/spi/cluster/hazelcast/HazelcastClusterManager.java
@@ -26,6 +26,7 @@ import com.hazelcast.core.LifecycleEvent;
 import com.hazelcast.core.LifecycleListener;
 import com.hazelcast.map.IMap;
 import io.vertx.core.Promise;
+import io.vertx.core.ServiceHelper;
 import io.vertx.core.Vertx;
 import io.vertx.core.VertxException;
 import io.vertx.core.internal.VertxInternal;
@@ -78,13 +79,8 @@ public class HazelcastClusterManager implements ClusterManager, MembershipListen
    * Constructor - gets config from classpath
    */
   public HazelcastClusterManager() {
-    Iterator<HazelcastObjectProvider> it = ServiceLoader.load(HazelcastObjectProvider.class).iterator();
-    if (it.hasNext()) {
-      objectProvider = it.next();
-      if (it.hasNext()) {
-        log.warn("Multiple HazelcastObjectProvider implementations were found, using first");
-      }
-    } else {
+    objectProvider = ServiceHelper.loadFactoryOrNull(HazelcastObjectProvider.class);
+    if (objectProvider == null) {
       objectProvider = new HazelcastObjectProviderImpl();
     }
   }

--- a/src/main/java/io/vertx/spi/cluster/hazelcast/HazelcastClusterManager.java
+++ b/src/main/java/io/vertx/spi/cluster/hazelcast/HazelcastClusterManager.java
@@ -24,7 +24,6 @@ import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.LifecycleEvent;
 import com.hazelcast.core.LifecycleListener;
-import com.hazelcast.cp.ISemaphore;
 import com.hazelcast.map.IMap;
 import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
@@ -42,10 +41,6 @@ import java.util.*;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.RejectedExecutionException;
-import java.util.concurrent.TimeUnit;
-
-import static java.util.concurrent.TimeUnit.MILLISECONDS;
-import static java.util.concurrent.TimeUnit.NANOSECONDS;
 
 /**
  * A cluster manager that uses Hazelcast
@@ -56,13 +51,13 @@ public class HazelcastClusterManager implements ClusterManager, MembershipListen
 
   private static final Logger log = LoggerFactory.getLogger(HazelcastClusterManager.class);
 
-  private static final String LOCK_SEMAPHORE_PREFIX = "__vertx.";
   private static final String NODE_ID_ATTRIBUTE = "__vertx.nodeId";
 
   private VertxInternal vertx;
   private NodeSelector nodeSelector;
 
   private HazelcastInstance hazelcast;
+  private HazelcastObjectProvider objectProvider;
   private volatile String nodeId;
   private NodeInfo nodeInfo;
   private SubsMapHelper subsMapHelper;
@@ -83,6 +78,15 @@ public class HazelcastClusterManager implements ClusterManager, MembershipListen
    * Constructor - gets config from classpath
    */
   public HazelcastClusterManager() {
+    Iterator<HazelcastObjectProvider> it = ServiceLoader.load(HazelcastObjectProvider.class).iterator();
+    if (it.hasNext()) {
+      objectProvider = it.next();
+      if (it.hasNext()) {
+        log.warn("Multiple HazelcastObjectProvider implementations were found, using first");
+      }
+    } else {
+      objectProvider = new HazelcastObjectProviderImpl();
+    }
   }
 
   /**
@@ -91,11 +95,13 @@ public class HazelcastClusterManager implements ClusterManager, MembershipListen
    * @param conf Hazelcast config, not null
    */
   public HazelcastClusterManager(Config conf) {
+    this();
     Objects.requireNonNull(conf, "The Hazelcast config cannot be null.");
     this.conf = conf;
   }
 
   public HazelcastClusterManager(HazelcastInstance instance) {
+    this();
     Objects.requireNonNull(instance, "The Hazelcast instance cannot be null.");
     hazelcast = instance;
     customHazelcastCluster = true;
@@ -146,6 +152,8 @@ public class HazelcastClusterManager implements ClusterManager, MembershipListen
         lifecycleListenerId = hazelcast.getLifecycleService().addLifecycleListener(this);
 
         nodeInfoMap = hazelcast.getMap("__vertx.nodeInfo");
+
+        objectProvider.onJoin(vertx, hazelcast, lockReleaseExec);
 
       }
       return null;
@@ -205,40 +213,23 @@ public class HazelcastClusterManager implements ClusterManager, MembershipListen
 
   @Override
   public <K, V> void getAsyncMap(String name, Promise<AsyncMap<K, V>> promise) {
-    promise.complete(new HazelcastAsyncMap<>(vertx, hazelcast.getMap(name)));
+    promise.complete(objectProvider.getAsyncMap(name));
   }
 
   @Override
   public <K, V> Map<K, V> getSyncMap(String name) {
-    return hazelcast.getMap(name);
+    return objectProvider.getSyncMap(name);
   }
 
   @Override
   public void getLockWithTimeout(String name, long timeout, Promise<Lock> promise) {
-    vertx.<Lock>executeBlocking(() -> {
-      ISemaphore iSemaphore = hazelcast.getCPSubsystem().getSemaphore(LOCK_SEMAPHORE_PREFIX + name);
-      boolean locked = false;
-      long remaining = timeout;
-      do {
-        long start = System.nanoTime();
-        try {
-          locked = iSemaphore.tryAcquire(remaining, TimeUnit.MILLISECONDS);
-        } catch (InterruptedException e) {
-          // OK continue
-        }
-        remaining = remaining - MILLISECONDS.convert(System.nanoTime() - start, NANOSECONDS);
-      } while (!locked && remaining > 0);
-      if (locked) {
-        return new HazelcastLock(iSemaphore, lockReleaseExec);
-      } else {
-        throw new VertxException("Timed out waiting to get lock " + name, true);
-      }
-    }, false).onComplete(promise);
+    vertx.executeBlocking(() -> objectProvider.getLockWithTimeout(name, timeout), false)
+      .onComplete(promise);
   }
 
   @Override
   public void getCounter(String name, Promise<Counter> promise) {
-    promise.complete(new HazelcastCounter(vertx, hazelcast.getCPSubsystem().getAtomicLong(name)));
+    promise.complete(objectProvider.createCounter(name));
   }
 
   @Override

--- a/src/main/java/io/vertx/spi/cluster/hazelcast/impl/HazelcastCounter.java
+++ b/src/main/java/io/vertx/spi/cluster/hazelcast/impl/HazelcastCounter.java
@@ -30,8 +30,10 @@ import io.vertx.core.shareddata.Counter;
  * Operations are impemented using {@link IMap#submitToKey(Object, EntryProcessor)}
  * which runs on the partition owner for the particular key (so it may run on a
  * remote member).
- * In Hazelcast operations on a specific key are executed by a single partition
- * thread on the owner of the partition for the key. This removes a lot of
+ * In Hazelcast, the operations on a specific key are executed by a single
+ * partition thread on the owner of the partition for the key.
+ * This removes a lot of complexity when dealing with concurrent access
+ * to the same key.
  */
 public class HazelcastCounter implements Counter {
 

--- a/src/main/java/io/vertx/spi/cluster/hazelcast/impl/HazelcastLock.java
+++ b/src/main/java/io/vertx/spi/cluster/hazelcast/impl/HazelcastLock.java
@@ -16,7 +16,7 @@
 
 package io.vertx.spi.cluster.hazelcast.impl;
 
-import com.hazelcast.cp.ISemaphore;
+import com.hazelcast.map.IMap;
 import io.vertx.core.shareddata.Lock;
 
 import java.util.concurrent.Executor;
@@ -24,19 +24,21 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 public class HazelcastLock implements Lock {
 
-  private final ISemaphore semaphore;
+  private final IMap<String, ?> lockMap;
+  private final String key;
   private final Executor lockReleaseExec;
   private final AtomicBoolean released = new AtomicBoolean();
 
-  public HazelcastLock(ISemaphore semaphore, Executor lockReleaseExec) {
-    this.semaphore = semaphore;
+  public HazelcastLock(IMap<String, ?> lockMap, String key, Executor lockReleaseExec) {
+    this.lockMap = lockMap;
+    this.key = key;
     this.lockReleaseExec = lockReleaseExec;
   }
 
   @Override
   public void release() {
     if (released.compareAndSet(false, true)) {
-      lockReleaseExec.execute(semaphore::release);
+      lockReleaseExec.execute(() -> lockMap.forceUnlock(key));
     }
   }
 }

--- a/src/main/java/io/vertx/spi/cluster/hazelcast/impl/HazelcastObjectProvider.java
+++ b/src/main/java/io/vertx/spi/cluster/hazelcast/impl/HazelcastObjectProvider.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2020 Red Hat, Inc.
+ *
+ * Red Hat licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.vertx.spi.cluster.hazelcast.impl;
+
+import com.hazelcast.core.HazelcastInstance;
+import io.vertx.core.internal.VertxInternal;
+import io.vertx.core.shareddata.AsyncMap;
+import io.vertx.core.shareddata.Counter;
+import io.vertx.core.shareddata.Lock;
+
+import java.util.Map;
+import java.util.concurrent.ExecutorService;
+
+/**
+ * SPI to allow different implementations of Map, AsyncMap, Lock and Counter
+ */
+public interface HazelcastObjectProvider {
+
+  /**
+   * Lifecycle method to initialize this provider when all dependencies become available,
+   */
+  void onJoin(VertxInternal vertx, HazelcastInstance hazelcast, ExecutorService lockReleaseExec);
+
+  /**
+   * Return {@link AsyncMap} for the given name
+   */
+  <K, V> AsyncMap<K, V> getAsyncMap(String name);
+
+  /**
+   * Return synchronous map for the given name
+   */
+  <K, V> Map<K,V> getSyncMap(String name);
+
+  /**
+   * Return Lock with the given name within specified timeout (in ms)
+   */
+  Lock getLockWithTimeout(String name, long timeout);
+
+  /**
+   * Return Counter with given name, if the Counter doesn't exist it is initialized to 0
+   */
+  Counter createCounter(String name);
+}

--- a/src/main/java/io/vertx/spi/cluster/hazelcast/impl/HazelcastObjectProviderImpl.java
+++ b/src/main/java/io/vertx/spi/cluster/hazelcast/impl/HazelcastObjectProviderImpl.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2020 Red Hat, Inc.
+ *
+ * Red Hat licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.vertx.spi.cluster.hazelcast.impl;
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.map.IMap;
+import io.vertx.core.VertxException;
+import io.vertx.core.internal.VertxInternal;
+import io.vertx.core.shareddata.AsyncMap;
+import io.vertx.core.shareddata.Counter;
+import io.vertx.core.shareddata.Lock;
+
+import java.util.Map;
+import java.util.concurrent.ExecutorService;
+
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.NANOSECONDS;
+
+/**
+ * Default implementation of {@link HazelcastObjectProvider} using open-source
+ * Hazelcast features
+ */
+public class HazelcastObjectProviderImpl implements HazelcastObjectProvider {
+
+  private static final String MAP_COUNTER_NAME = "__vertx.map.counter";
+  private static final String MAP_LOCK_NAME = "__vertx.map.lock";
+
+  private VertxInternal vertx;
+  private HazelcastInstance hazelcast;
+  private ExecutorService lockReleaseExec;
+
+  @Override
+  public void onJoin(VertxInternal vertx, HazelcastInstance hazelcast, ExecutorService lockReleaseExec) {
+    this.vertx = vertx;
+    this.hazelcast = hazelcast;
+    this.lockReleaseExec = lockReleaseExec;
+  }
+
+  @Override
+  public <K, V> AsyncMap<K, V> getAsyncMap(String name) {
+    return new HazelcastAsyncMap<>(vertx, hazelcast.getMap(name));
+  }
+
+  @Override
+  public <K, V> Map<K, V> getSyncMap(String name) {
+    return hazelcast.getMap(name);
+  }
+
+  @Override
+  public Lock getLockWithTimeout(String name, long timeout) {
+    IMap<String, Object> lockMap = hazelcast.getMap(MAP_LOCK_NAME);
+    boolean locked = false;
+    long remaining = timeout;
+    do {
+      long start = System.nanoTime();
+      try {
+        locked = lockMap.tryLock(name, timeout, MILLISECONDS);
+      } catch (InterruptedException e) {
+        // OK continue
+      }
+      remaining = remaining - MILLISECONDS.convert(System.nanoTime() - start, NANOSECONDS);
+    } while (!locked && remaining > 0);
+    if (locked) {
+      return new HazelcastLock(lockMap, name, lockReleaseExec);
+    } else {
+      throw new VertxException("Timed out waiting to get lock " + name, true);
+    }
+  }
+
+  @Override
+  public Counter createCounter(String name) {
+    return new HazelcastCounter(vertx, hazelcast.getMap(MAP_COUNTER_NAME), name);
+  }
+}

--- a/src/main/resources/default-cluster.xml
+++ b/src/main/resources/default-cluster.xml
@@ -39,15 +39,4 @@
     <backup-count>1</backup-count>
   </map>
 
-  <cp-subsystem>
-    <cp-member-count>0</cp-member-count>
-    <semaphores>
-      <semaphore>
-        <name>__vertx.*</name>
-        <jdk-compatible>false</jdk-compatible>
-        <initial-permits>1</initial-permits>
-      </semaphore>
-    </semaphores>
-  </cp-subsystem>
-
 </hazelcast>

--- a/src/test/resources/cluster.xml
+++ b/src/test/resources/cluster.xml
@@ -45,15 +45,4 @@
     <backup-count>1</backup-count>
   </map>
 
-  <cp-subsystem>
-    <cp-member-count>0</cp-member-count>
-    <semaphores>
-      <semaphore>
-        <name>__vertx.*</name>
-        <jdk-compatible>false</jdk-compatible>
-        <initial-permits>1</initial-permits>
-      </semaphore>
-    </semaphores>
-  </cp-subsystem>
-
 </hazelcast>


### PR DESCRIPTION
Hazelcast is removing the CP subsystem from its open-source edition in the upcoming release 5.5.

This PR introduces a new SPI - HazelcastObjectProvider, which allows changing the implementation of the sync/async map, locks and counters.

The default implementation uses IMap to implement the counter and lock. This implementation should work across all released Hazelcast versions. The existing test coverage of the lock and counter seems sufficient.

Hazelcast will provide another implementation in their own module based on the CP subsystem available in their enterprise edition.
