### PR TITLE
Update CI for 5.x branch to run with multiple Hazelcast versions

### DIFF
--- a/.github/workflows/ci-5.x.yml
+++ b/.github/workflows/ci-5.x.yml
@@ -12,26 +12,36 @@ jobs:
   CI:
     strategy:
       matrix:
+        os: [ ubuntu-latest ]
+        jdk: [ 17 ]
+        hz: [  5.4.0, 5.5.0 ]
         include:
           - os: ubuntu-latest
             jdk: 11
+            hz: 5.3.8
     uses: ./.github/workflows/ci.yml
     with:
       branch: ${{ github.event.pull_request.head.sha || github.ref_name }}
       jdk: ${{ matrix.jdk }}
       os: ${{ matrix.os }}
+      hz: ${{ matrix.hz }}
     secrets: inherit
   IT:
     strategy:
       matrix:
+        os: [ ubuntu-latest ]
+        jdk: [ 17 ]
+        hz: [ 5.4.0, 5.5.0 ]
         include:
           - os: ubuntu-latest
             jdk: 11
+            hz: 5.3.8
     uses: ./.github/workflows/it.yml
     with:
       branch: ${{ github.event.pull_request.head.sha || github.ref_name }}
       jdk: ${{ matrix.jdk }}
       os: ${{ matrix.os }}
+      hz: ${{ matrix.hz }}
     secrets: inherit
   Deploy:
     if: ${{ github.repository_owner == 'vert-x3' && (github.event_name == 'push' || github.event_name == 'schedule') }}

--- a/.github/workflows/ci-5.x.yml
+++ b/.github/workflows/ci-5.x.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest ]
-        jdk: [ 17 ]
+        jdk: [ 21 ]
         hz: [  5.4.0, 5.5.0 ]
         include:
           - os: ubuntu-latest
@@ -30,7 +30,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest ]
-        jdk: [ 17 ]
+        jdk: [ 21 ]
         hz: [ 5.4.0, 5.5.0 ]
         include:
           - os: ubuntu-latest


### PR DESCRIPTION
Motivation:

Test with multiple Hazelcast versions.

Note that Hazelcast 5.4.0 requires Java 17.

Fixes #199
