### PR TITLE
Fix package name for ClusteredSessionHandlerTest

### DIFF
--- a/vertx-hazelcast-it/src/test/java/io/vertx/spi/cluster/hazelcast/tests/sstore/HazelcastClusteredSessionHandlerTest.java
+++ b/vertx-hazelcast-it/src/test/java/io/vertx/spi/cluster/hazelcast/tests/sstore/HazelcastClusteredSessionHandlerTest.java
@@ -20,7 +20,7 @@ import io.vertx.spi.cluster.hazelcast.tests.Lifecycle;
 import io.vertx.spi.cluster.hazelcast.tests.LoggingTestWatcher;
 import io.vertx.core.Vertx;
 import io.vertx.core.spi.cluster.ClusterManager;
-import io.vertx.ext.web.sstore.ClusteredSessionHandlerTest;
+import io.vertx.ext.web.it.sstore.ClusteredSessionHandlerTest;
 import io.vertx.spi.cluster.hazelcast.HazelcastClusterManager;
 import org.junit.Rule;
 


### PR DESCRIPTION
Fixes compile failure in `vertx-hazelcast-it`