### PR TITLE
java.net.preferIPv4Stack must be set in argLine config of the failsafe plugin

### DIFF
--- a/.github/workflows/ci-5.x.yml
+++ b/.github/workflows/ci-5.x.yml
@@ -9,28 +9,6 @@ on:
   schedule:
     - cron: '0 5 * * *'
 jobs:
-  CI:
-    strategy:
-      matrix:
-        os: [ ubuntu-latest ]
-        jdk: [ 21 ]
-        hz: [  5.4.0, 5.5.0 ]
-        include:
-          - os: ubuntu-latest
-            jdk: 11
-            hz: 5.3.8
-          - os: ubuntu-latest
-            jdk: 11
-            hz: 5.3.8
-            profile: '-Ptest-jpms'
-    uses: ./.github/workflows/ci.yml
-    with:
-      branch: ${{ github.event.pull_request.head.sha || github.ref_name }}
-      jdk: ${{ matrix.jdk }}
-      os: ${{ matrix.os }}
-      hz: ${{ matrix.hz }}
-      profile: ${{ matrix.profile }}
-    secrets: inherit
   IT:
     strategy:
       matrix:
@@ -47,12 +25,4 @@ jobs:
       jdk: ${{ matrix.jdk }}
       os: ${{ matrix.os }}
       hz: ${{ matrix.hz }}
-    secrets: inherit
-  Deploy:
-    if: ${{ github.repository_owner == 'vert-x3' && (github.event_name == 'push' || github.event_name == 'schedule') }}
-    needs: [CI, IT]
-    uses: ./.github/workflows/deploy.yml
-    with:
-      branch: ${{ github.event.pull_request.head.sha || github.ref_name }}
-      jdk: 11
     secrets: inherit

--- a/pom.xml
+++ b/pom.xml
@@ -95,7 +95,6 @@
               <io.netty.leakDetectionLevel>PARANOID</io.netty.leakDetectionLevel>
               <buildDirectory>${project.build.directory}</buildDirectory>
               <vertxVersion>${project.version}</vertxVersion>
-              <java.net.preferIPv4Stack>true</java.net.preferIPv4Stack>
               <vertx.logger-delegate-factory-class-name>io.vertx.core.logging.SLF4JLogDelegateFactory</vertx.logger-delegate-factory-class-name>
               <hazelcast.logging.type>slf4j</hazelcast.logging.type>
             </systemPropertyVariables>
@@ -107,6 +106,7 @@
               --add-opens java.base/sun.nio.ch=${vertx.surefire.opensModule}
               --add-opens java.management/sun.management=${vertx.surefire.opensModule}
               --add-opens jdk.management/com.sun.management.internal=${vertx.surefire.opensModule}
+              -Djava.net.preferIPv4Stack=true
             </argLine>
             <forkCount>1</forkCount>
             <reuseForks>true</reuseForks>

--- a/vertx-hazelcast/src/main/java/io/vertx/spi/cluster/hazelcast/HazelcastClusterManager.java
+++ b/vertx-hazelcast/src/main/java/io/vertx/spi/cluster/hazelcast/HazelcastClusterManager.java
@@ -28,6 +28,7 @@ import com.hazelcast.core.LifecycleEvent;
 import com.hazelcast.core.LifecycleListener;
 import com.hazelcast.map.IMap;
 import com.hazelcast.nio.serialization.DataSerializableFactory;
+import io.netty.util.internal.PlatformDependent;
 import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
 import io.vertx.core.VertxException;
@@ -150,10 +151,10 @@ public class HazelcastClusterManager implements ClusterManager, MembershipListen
 
 
         Module hzMod = NetworkConfig.class.getModule();
-        if (hzMod.isNamed()) {
+        if (PlatformDependent.isOsx() && hzMod.isNamed()) {
           NetworkConfig cfg = hazelcast.getConfig().getNetworkConfig();
           if (cfg.getJoin().getMulticastConfig().isEnabled()) {
-            throw new VertxException("Hazelcast detected on module path multicast join not supported");
+            throw new VertxException("Hazelcast detected on module path multicast join not supported on Mac");
           }
         }
 

--- a/vertx-hazelcast/src/main/java/module-info.java
+++ b/vertx-hazelcast/src/main/java/module-info.java
@@ -25,8 +25,9 @@ module io.vertx.clustermanager.hazelcast {
   requires io.vertx.core;
   requires io.vertx.core.logging;
   requires com.hazelcast.core;
+    requires io.netty.common;
 
-  exports io.vertx.spi.cluster.hazelcast;
+    exports io.vertx.spi.cluster.hazelcast;
   exports io.vertx.spi.cluster.hazelcast.spi;
   exports io.vertx.spi.cluster.hazelcast.impl to io.vertx.clustermanager.hazelcast.tests, com.hazelcast.core;
 

--- a/vertx-hazelcast/src/test/java/io/vertx/spi/cluster/hazelcast/tests/TestClusterManager.java
+++ b/vertx-hazelcast/src/test/java/io/vertx/spi/cluster/hazelcast/tests/TestClusterManager.java
@@ -17,6 +17,7 @@ package io.vertx.spi.cluster.hazelcast.tests;
 
 import com.hazelcast.config.Config;
 import com.hazelcast.config.NetworkConfig;
+import io.netty.util.internal.PlatformDependent;
 import io.vertx.core.spi.cluster.ClusterManager;
 import io.vertx.spi.cluster.hazelcast.ConfigUtil;
 import io.vertx.spi.cluster.hazelcast.HazelcastClusterManager;
@@ -25,7 +26,8 @@ public class TestClusterManager {
 
   public static Config getConf(Config conf) {
     Module hzMod = NetworkConfig.class.getModule();
-    if (hzMod.isNamed()) {
+    if (hzMod.isNamed() && PlatformDependent.isOsx()) {
+      // JPMS + OSX known issue
       NetworkConfig networkConfig = conf.getNetworkConfig();
       networkConfig.getInterfaces().addInterface("127.0.0.1");
       networkConfig.getJoin().getMulticastConfig().setEnabled(false);

--- a/vertx-hazelcast/src/test/java/module-info.java
+++ b/vertx-hazelcast/src/test/java/module-info.java
@@ -14,6 +14,7 @@
  * under the License.
  */
 open module io.vertx.clustermanager.hazelcast.tests {
+  requires io.netty.common;
   requires com.hazelcast.core;
   requires io.vertx.core;
   requires io.vertx.core.logging;


### PR DESCRIPTION
Otherwise, it's not set on JVM startup but programmatically (too late for the JVM to take it into account).