### PR TITLE
Expose cluster spi impl to com.hazelcast.vertx (Vertx Hazelcast EE)

### DIFF
--- a/vertx-hazelcast/src/main/java/module-info.java
+++ b/vertx-hazelcast/src/main/java/module-info.java
@@ -29,6 +29,7 @@ module io.vertx.clustermanager.hazelcast {
 
   exports io.vertx.spi.cluster.hazelcast;
   exports io.vertx.spi.cluster.hazelcast.spi;
+  // com.hazelcast.vertx export is needed for Vert.x Hazelcast EE (CP-based) library test.
   exports io.vertx.spi.cluster.hazelcast.impl to io.vertx.clustermanager.hazelcast.tests, com.hazelcast.core, com.hazelcast.vertx;
 
   uses io.vertx.spi.cluster.hazelcast.spi.HazelcastObjectProvider;

--- a/vertx-hazelcast/src/main/java/module-info.java
+++ b/vertx-hazelcast/src/main/java/module-info.java
@@ -25,11 +25,11 @@ module io.vertx.clustermanager.hazelcast {
   requires io.vertx.core;
   requires io.vertx.core.logging;
   requires com.hazelcast.core;
-    requires io.netty.common;
+  requires io.netty.common;
 
-    exports io.vertx.spi.cluster.hazelcast;
+  exports io.vertx.spi.cluster.hazelcast;
   exports io.vertx.spi.cluster.hazelcast.spi;
-  exports io.vertx.spi.cluster.hazelcast.impl to io.vertx.clustermanager.hazelcast.tests, com.hazelcast.core;
+  exports io.vertx.spi.cluster.hazelcast.impl to io.vertx.clustermanager.hazelcast.tests, com.hazelcast.core, com.hazelcast.vertx;
 
   uses io.vertx.spi.cluster.hazelcast.spi.HazelcastObjectProvider;
 


### PR DESCRIPTION
Motivation:

In Hazelcast Enterprise Vertx module we would need to use `io.vertx.spi.cluster.hazelcast.impl` classes: ConversionUtils and HazelcastObjectProviderImpl. Without this change it's impossible to use those classes if using modulepath.
